### PR TITLE
Support guest filtering in GET /api/notes/ 

### DIFF
--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -1,36 +1,25 @@
 # backend/notes/views.py
-# Remove these imports if they are only for save_note function:
-# import json
-# from django.http import JsonResponse
-# from django.views.decorators.csrf import csrf_exempt
-# from django.shortcuts import get_object_or_404
-# from django.contrib.auth import get_user_model
 
-# Import DRF generics and APIView, and your models and serializers
-from rest_framework import generics # For ListCreateAPIView
-from rest_framework.views import APIView # If you want to use this instead of generics
-from rest_framework.response import Response # For custom responses
-from rest_framework import status # For HTTP status codes
+from rest_framework import generics  # For ListCreateAPIView
+from rest_framework.response import Response  # For custom responses
+from rest_framework import status  # For HTTP status codes
 
 from .models import Note
-from .serializers import NoteSerializer # Import your new NoteSerializer
+from .serializers import NoteSerializer  # Import your NoteSerializer
 
-# Remove the Mood import if Mood is only used within NoteSerializer's create method
-# from moods.models import Mood
-
+# This view handles both GET (list notes) and POST (create note)
 class NoteListCreateAPIView(generics.ListCreateAPIView):
-    # For GET requests (listing notes)
-    queryset = Note.objects.all().order_by('-created_at') # Order by most recent
     serializer_class = NoteSerializer
 
+    def get_queryset(self):
+        """
+        Optionally filters notes by guest_uuid (user.id),
+        returns all notes ordered by most recent by default.
+        """
+        guest_uuid = self.request.query_params.get('guest_uuid')
+        queryset = Note.objects.all().order_by('-created_at')
+        if guest_uuid:
+            queryset = queryset.filter(user__id=guest_uuid)
+        return queryset
 
-    # No need for a separate 'create' method here unless you have custom logic
-    # beyond what the serializer's create method handles.
-    # The serializer's create() method will be called automatically on POST.
-    # You might want to override perform_create to set the user if you are using authentication
-    # def perform_create(self, serializer):
-    #    serializer.save(user=self.request.user) # Example if user is authenticated
-
-# Remove the old @csrf_exempt def save_note(request): function entirely.
-# Its logic is now handled by NoteSerializer.create() and ListCreateAPIView's default POST behavior.
-
+  


### PR DESCRIPTION
## What this PR does
- Adds support for `?guest_uuid=` param in `GET /api/notes/`
- Filters notes by user UUID
- Does not alter DB schema or existing logic

## How to Test
- Create some notes with different users
- Call: `/api/v1/notes/?guest_uuid=<uuid>`
- Confirm it only returns matching user notes

Closes #22 
