### PR TITLE
feat: Implement notes detail views and serializers for edit/delete

### DIFF
--- a/backend/notes/serializers.py
+++ b/backend/notes/serializers.py
@@ -1,50 +1,59 @@
 # backend/notes/serializers.py
+
 from rest_framework import serializers
 from .models import Note
-from moods.serializers import MoodSerializer
-from django.contrib.auth import get_user_model
+from moods.serializers import MoodSerializer # Assuming you have this
+from users.serializers import CustomUserSerializer # Assuming you have this
+from moods.models import Mood # Import Mood model
+from users.models import CustomUser # Import CustomUser model
 
 class NoteSerializer(serializers.ModelSerializer):
-    user_id = serializers.UUIDField(write_only=True)
+    user = CustomUserSerializer(read_only=True) # Nested user for output
+    user_id = serializers.CharField(write_only=True) # For input
+    mood = MoodSerializer(read_only=True) # Nested mood for output
     mood_name = serializers.CharField(write_only=True, required=False, allow_blank=True) # For input
-
-    # If you want to nest the mood object in output
-    mood = MoodSerializer(read_only=True)
 
     class Meta:
         model = Note
-        # --- IMPORTANT CHANGE HERE ---
-        # Ensure 'note' is in this tuple/list instead of 'content'
         fields = ['id', 'user', 'mood', 'note', 'created_at', 'updated_at', 'user_id', 'mood_name']
-        read_only_fields = ['id', 'user', 'mood', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+    # We need to make 'note' not required for validation at the serializer level if it's blank=True in model
+    # However, ModelSerializer usually respects blank=True/null=True from the model.
+    # If you get errors for 'note' being required when empty, you might add:
+    # note = serializers.CharField(required=False, allow_blank=True)
+    # But usually, the model's blank=True is enough.
 
     def create(self, validated_data):
         user_id = validated_data.pop('user_id')
         mood_name = validated_data.pop('mood_name', None)
 
-        User = get_user_model()
         try:
-            user_obj = User.objects.get(id=user_id)
-        except User.DoesNotExist:
-            raise serializers.ValidationError({'user_id': 'Invalid or non-existent user_id.'})
+            user_obj = CustomUser.objects.get(id=user_id)
+        except CustomUser.DoesNotExist:
+            raise serializers.ValidationError({'user_id': 'Invalid user ID.'})
 
         mood_obj = None
         if mood_name:
             try:
-                from moods.models import Mood # Import here to avoid circular dependency
                 mood_obj = Mood.objects.get(name__iexact=mood_name)
             except Mood.DoesNotExist:
-                raise serializers.ValidationError({'mood': f"Mood '{mood_name}' not found."})
+                raise serializers.ValidationError({'mood_name': f"Mood '{mood_name}' not found."})
 
-        # Create the note instance, ensuring 'note' field is used
         note_instance = Note.objects.create(user=user_obj, mood=mood_obj, **validated_data)
         return note_instance
 
-    def to_representation(self, instance):
-        # This method controls how the output JSON looks
-        representation = super().to_representation(instance)
-        # Ensure 'note' is used for output if you have a custom representation
-        # If you are just using 'fields' in Meta, DRF handles this automatically.
-        # Example if you want to explicitly include 'note' in output:
-        # representation['note'] = instance.note
-        return representation
+    def update(self, instance, validated_data):
+        # Handle mood_name if it was explicitly passed for update
+        # This part is largely handled in the view's .update() override,
+        # where we convert mood_name to mood_id.
+        # So here, we just apply the validated_data directly.
+        # If 'mood' is in validated_data (because view processed mood_name)
+        if 'mood' in validated_data:
+            instance.mood = validated_data.pop('mood') # Update the mood foreign key
+
+        # Update other fields passed in validated_data
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance

--- a/backend/notes/urls.py
+++ b/backend/notes/urls.py
@@ -1,9 +1,8 @@
 # backend/notes/urls.py
 from django.urls import path
-from .views import NoteListCreateAPIView # Import your new class-based view
+from .views import NoteListCreateAPIView, NoteDetailAPIView # Import the new view
 
 urlpatterns = [
-    # This single path now handles both GET (list notes) and POST (create note)
-
-    path('', NoteListCreateAPIView.as_view(), name='note-list-create'),
+    path('notes/', NoteListCreateAPIView.as_view(), name='note-list-create'),
+    path('notes/<uuid:id>/', NoteDetailAPIView.as_view(), name='note-detail'), # New URL pattern
 ]

--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -1,36 +1,95 @@
 # backend/notes/views.py
-# Remove these imports if they are only for save_note function:
-# import json
-# from django.http import JsonResponse
-# from django.views.decorators.csrf import csrf_exempt
-# from django.shortcuts import get_object_or_404
-# from django.contrib.auth import get_user_model
 
-# Import DRF generics and APIView, and your models and serializers
-from rest_framework import generics # For ListCreateAPIView
-from rest_framework.views import APIView # If you want to use this instead of generics
-from rest_framework.response import Response # For custom responses
-from rest_framework import status # For HTTP status codes
-
+from rest_framework import generics, status
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly # Added IsAuthenticatedOrReadOnly
+from rest_framework import serializers # Good for ValidationError
+from .permissions import IsOwner # Only import IsOwner
 from .models import Note
-from .serializers import NoteSerializer # Import your new NoteSerializer
+from .serializers import NoteSerializer
+from moods.models import Mood
+from users.models import CustomUser
+import uuid # This import is not strictly needed in the final code here, but fine to keep for now if you might use it.
 
-# Remove the Mood import if Mood is only used within NoteSerializer's create method
-# from moods.models import Mood
 
+# --- This is for list and create ---
 class NoteListCreateAPIView(generics.ListCreateAPIView):
-    # For GET requests (listing notes)
-    queryset = Note.objects.all().order_by('-created_at') # Order by most recent
+    queryset = Note.objects.all()
     serializer_class = NoteSerializer
+    # Changed to DRF's standard permission for this behavior
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def perform_create(self, serializer):
+        user_id_str = self.request.data.get('user_id')
+        mood_name = self.request.data.get('mood_name')
+        note_content = self.request.data.get('note', '')
+
+        if not user_id_str:
+            raise serializers.ValidationError({'user_id': 'user_id is required.'})
+
+        try:
+            user_obj = CustomUser.objects.get(id=user_id_str)
+        except (CustomUser.DoesNotExist, ValueError):
+            raise serializers.ValidationError({'user_id': 'Invalid or non-existent user_id.'})
+
+        mood_obj = None
+        if mood_name:
+            try:
+                mood_obj = Mood.objects.get(name__iexact=mood_name)
+            except Mood.DoesNotExist:
+                raise serializers.ValidationError({'mood_name': f"Mood '{mood_name}' not found."})
+
+        # Save the note with the determined user, mood, and content
+        serializer.save(user=user_obj, mood=mood_obj, note=note_content)
 
 
-    # No need for a separate 'create' method here unless you have custom logic
-    # beyond what the serializer's create method handles.
-    # The serializer's create() method will be called automatically on POST.
-    # You might want to override perform_create to set the user if you are using authentication
-    # def perform_create(self, serializer):
-    #    serializer.save(user=self.request.user) # Example if user is authenticated
+# --- This is for Retrieve, Update, Delete ---
+class NoteDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Note.objects.all()
+    serializer_class = NoteSerializer
+    # Corrected permission class name
+    permission_classes = [IsAuthenticated, IsOwner]
+    lookup_field = 'id'
 
-# Remove the old @csrf_exempt def save_note(request): function entirely.
-# Its logic is now handled by NoteSerializer.create() and ListCreateAPIView's default POST behavior.
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
 
+        # Create a mutable copy of request.data for processing
+        data = request.data.copy()
+
+        # Custom logic for mood_name during update
+        mood_name = data.get('mood_name')
+        if mood_name is not None: # Check if mood_name was provided in the request payload
+            if mood_name: # If provided and not empty, find the mood object
+                try:
+                    mood_obj = Mood.objects.get(name__iexact=mood_name)
+                    # Set the 'mood' field in the data to the Mood object's ID
+                    # This is what the serializer expects for the ForeignKey
+                    data['mood'] = str(mood_obj.id)
+                except Mood.DoesNotExist:
+                    return Response({'mood_name': f"Mood '{mood_name}' not found."},
+                                    status=status.HTTP_400_BAD_REQUEST)
+            else: # If mood_name was provided but empty, set mood to null
+                data['mood'] = None
+        
+        # Remove mood_name from the data *before* passing to serializer,
+        # as it's a write_only field for custom logic, not a model field.
+        if 'mood_name' in data:
+            data.pop('mood_name')
+
+        serializer = self.get_serializer(instance, data=data, partial=partial)
+        serializer.is_valid(raise_exception=True) # Validate the data
+
+        self.perform_update(serializer) # Perform the actual update on the instance
+
+        # If you were prefetching related objects, you might need to refresh
+        # the instance from the DB to get updated nested fields.
+        # Otherwise, the serializer.instance after perform_update is usually fine.
+        # In this case, let's re-serialize the instance for consistent output.
+        return Response(self.get_serializer(instance).data)
+
+    # perform_destroy is usually handled fine by the default RetrieveUpdateDestroyAPIView
+    # You only need to override it if you have custom logic for deletion (e.g., logging)
+    # def perform_destroy(self, instance):
+    #     instance.delete()

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,0 +1,8 @@
+# backend/users/serializers.py
+from rest_framework import serializers
+from .models import CustomUser # Make sure to import your CustomUser model
+
+class CustomUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = ['id', 'username', 'email'] # Or whatever fields you want to expose


### PR DESCRIPTION
Closes #26  This PR introduces the `PUT`, `PATCH`, and `DELETE` endpoints for individual note entries, enhancing the notes API functionality.

**Key Changes:**
- Adds `NoteDetailAPIView` to handle `GET` (single), `PUT`, `PATCH`, and `DELETE` operations on `/api/v1/notes/:id/`.
- Implements `IsOwner` custom permission to ensure only the owner of a note can modify or delete it.
- Updates `notes/urls.py` to include the new detail URL pattern.
- Updates `notes/serializers.py` to correctly handle note updates, especially for `mood_name`.
- Comprehensive updates to `backend/api_docs/notes_api.md` detailing the new endpoints, request/response formats, and permission requirements.

**Testing Notes:**
- Verify `GET /api/v1/notes/{id}/` returns 200 for owner, 403 for others.
- Verify `PUT /api/v1/notes/{id}/` updates notes for owner (full update), returns 403 for others.
- Verify `PATCH /api/v1/notes/{id}/` updates notes for owner (partial update), returns 403 for others.
- Verify `DELETE /api/v1/notes/{id}/` deletes notes for owner, returns 403 for others.