### PR TITLE
Implement Token Authentication and Route Protection (Closes #39)

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -24,6 +24,5 @@ urlpatterns = [
     path('api/v1/moods/', include('moods.urls')),
     path('api/v1/notes/', include('notes.urls')),
     path('api/v1/auth/', include('users.urls')),
-    path('api/v1/token/', obtain_auth_token, name='api_token_auth'),
 
 ]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -16,10 +16,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework.authtoken.views import obtain_auth_token
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/moods/', include('moods.urls')),
     path('api/v1/notes/', include('notes.urls')),
     path('api/v1/auth/', include('users.urls')),
+    path('api/v1/token/', obtain_auth_token, name='api_token_auth'),
+
 ]

--- a/backend/notes/urls.py
+++ b/backend/notes/urls.py
@@ -3,8 +3,8 @@ from django.urls import path
 from .views import NoteListCreateAPIView, NoteDetailAPIView  # Import the new view
 
 urlpatterns = [
-    path("notes/", NoteListCreateAPIView.as_view(), name="note-list-create"),
+    path("", NoteListCreateAPIView.as_view(), name="note-list-create"),
     path(
-        "notes/<uuid:id>/", NoteDetailAPIView.as_view(), name="note-detail"
+        "<uuid:id>/", NoteDetailAPIView.as_view(), name="note-detail"
     ),  # New URL pattern
 ]


### PR DESCRIPTION
### What This PR Does

This PR implements route protection using Django REST Framework's TokenAuthentication and permission classes. It ensures that only authenticated users can access protected endpoints like `/api/v1/notes/`.

### Implemented

- Removed redundant `/api/v1/token/` route after verifying `/auth/login/` handles token issuance
- Simplified notes URLs by removing the redundant /notes/notes/ structure
- Verified token access with Postman
- Linked to issue: Closes #39 

### Files Modified

- `backend/config/urls.py`
- `backend/notes/urls.py`

### Testing Instructions
1. Use `/auth/login/` to obtain a token (dj-rest-auth)
2. Include `Authorization: Token <your_token>` in request headers
3. Confirm protected routes respond with `403` if unauthenticated, and `200` if token is valid

