### PR TITLE
feat: complete backend notes API and migration endpoint

### DIFF
--- a/backend/notes/serializers.py
+++ b/backend/notes/serializers.py
@@ -2,74 +2,47 @@
 
 from rest_framework import serializers
 from .models import Note
-from moods.serializers import MoodSerializer  # Assuming you have this
-from users.serializers import CustomUserSerializer  # Assuming you have this
-from moods.models import Mood  # Import Mood model
-from users.models import CustomUser  # Import CustomUser model
+from moods.serializers import MoodSerializer
+from django.contrib.auth import get_user_model
+from moods.models import Mood
 
+User = get_user_model()
 
 class NoteSerializer(serializers.ModelSerializer):
-    user = CustomUserSerializer(read_only=True)  # Nested user for output
-    user_id = serializers.CharField(write_only=True)  # For input
-    mood = MoodSerializer(read_only=True)  # Nested mood for output
-    mood_name = serializers.CharField(
-        write_only=True, required=False, allow_blank=True
-    )  # For input
-
+    """
+    Serializer for READ, UPDATE, DELETE operations.
+    It includes nested mood data for the response.
+    """
+    mood = MoodSerializer(read_only=True)
+    
     class Meta:
         model = Note
-        fields = [
-            "id",
-            "user",
-            "mood",
-            "note",
-            "created_at",
-            "updated_at",
-            "user_id",
-            "mood_name",
-        ]
-        read_only_fields = ["id", "created_at", "updated_at"]
-
-    # We need to make 'note' not required for validation at the serializer level if it's blank=True in model
-    # However, ModelSerializer usually respects blank=True/null=True from the model.
-    # If you get errors for 'note' being required when empty, you might add:
-    # note = serializers.CharField(required=False, allow_blank=True)
-    # But usually, the model's blank=True is enough.
-
-    def create(self, validated_data):
-        user_id = validated_data.pop("user_id")
-        mood_name = validated_data.pop("mood_name", None)
-
-        try:
-            user_obj = CustomUser.objects.get(id=user_id)
-        except CustomUser.DoesNotExist:
-            raise serializers.ValidationError({"user_id": "Invalid user ID."})
-
-        mood_obj = None
-        if mood_name:
-            try:
-                mood_obj = Mood.objects.get(name__iexact=mood_name)
-            except Mood.DoesNotExist:
-                raise serializers.ValidationError(
-                    {"mood_name": f"Mood '{mood_name}' not found."}
-                )
-
-        note_instance = Note.objects.create(
-            user=user_obj, mood=mood_obj, **validated_data
-        )
-        return note_instance
+        fields = ['id', 'user', 'mood', 'note', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'user', 'mood', 'created_at', 'updated_at']
 
     def update(self, instance, validated_data):
-        # Handle mood_name if it was explicitly passed for update
-        # This part is largely handled in the view's .update() override,
-        # where we convert mood_name to mood_id.
-        # So here, we just apply the validated_data directly.
-        # If 'mood' is in validated_data (because view processed mood_name)
-        if "mood" in validated_data:
-            instance.mood = validated_data.pop("mood")  # Update the mood foreign key
-
-        # Update other fields passed in validated_data
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         instance.save()
         return instance
+
+class NoteCreateSerializer(serializers.ModelSerializer):
+    """
+    Serializer for CREATE operations (POST requests).
+    It accepts 'mood_name' to link a mood.
+    """
+    mood_name = serializers.CharField(write_only=True, required=False, allow_blank=True)
+
+    class Meta:
+        model = Note
+        fields = ['note', 'mood_name']
+
+class NoteMigrationSerializer(serializers.Serializer):
+    """
+    Serializer for the bulk migration endpoint.
+    It validates a list of 'NoteCreateSerializer' objects.
+    """
+    entries = NoteCreateSerializer(many=True)
+
+    def create(self, validated_data):
+        return validated_data

--- a/backend/notes/urls.py
+++ b/backend/notes/urls.py
@@ -1,10 +1,11 @@
 # backend/notes/urls.py
+
 from django.urls import path
-from .views import NoteListCreateAPIView, NoteDetailAPIView  # Import the new view
+from .views import NoteListCreateAPIView, NoteDetailAPIView, NoteMigrationAPIView
 
 urlpatterns = [
+    # The 'notes/' prefix is now handled by config/urls.py, so we remove it here.
     path("", NoteListCreateAPIView.as_view(), name="note-list-create"),
-    path(
-        "<uuid:id>/", NoteDetailAPIView.as_view(), name="note-detail"
-    ),  # New URL pattern
+    path("<uuid:pk>/", NoteDetailAPIView.as_view(), name="note-detail"),
+    path("migrate/", NoteMigrationAPIView.as_view(), name="note-migrate"),
 ]

--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -1,71 +1,90 @@
 # backend/notes/views.py
 
-from rest_framework import generics  # For ListCreateAPIView
-from rest_framework.response import Response  # For custom responses
-from rest_framework import status  # For HTTP status codes
 from rest_framework import generics, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.exceptions import ValidationError
 from .models import Note
-from .serializers import NoteSerializer
+from .serializers import (
+    NoteSerializer,
+    NoteCreateSerializer,
+    NoteMigrationSerializer,
+)
+from moods.models import Mood
 
-
-# This view handles both GET (list notes) and POST (create note)
 class NoteListCreateAPIView(generics.ListCreateAPIView):
-
-    serializer_class = NoteSerializer
-    # Corrected permission class name
+    """
+    Handles GET (list all notes for a user) and POST (create a new note).
+    """
+    serializer_class = NoteCreateSerializer
     permission_classes = [IsAuthenticated]
-    lookup_field = "id"
-
-    def update(self, request, *args, **kwargs):
-        partial = kwargs.pop("partial", False)
-        instance = self.get_object()
-
-        # Create a mutable copy of request.data for processing
-        data = request.data.copy()
-
-        # Custom logic for mood_name during update
-        mood_name = data.get("mood_name")
-        if (
-            mood_name is not None
-        ):  # Check if mood_name was provided in the request payload
-            if mood_name:  # If provided and not empty, find the mood object
-                try:
-                    mood_obj = Mood.objects.get(name__iexact=mood_name)
-                    # Set the 'mood' field in the data to the Mood object's ID
-                    # This is what the serializer expects for the ForeignKey
-                    data["mood"] = str(mood_obj.id)
-                except Mood.DoesNotExist:
-                    return Response(
-                        {"mood_name": f"Mood '{mood_name}' not found."},
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-            else:  # If mood_name was provided but empty, set mood to null
-                data["mood"] = None
-
-        # Remove mood_name from the data *before* passing to serializer,
-        # as it's a write_only field for custom logic, not a model field.
-        if "mood_name" in data:
-            data.pop("mood_name")
-
-        serializer = self.get_serializer(instance, data=data, partial=partial)
-        serializer.is_valid(raise_exception=True)  # Validate the data
 
     def get_queryset(self):
-        """
-        Optionally filters notes by guest_uuid (user.id),
-        returns all notes ordered by most recent by default.
-        """
-        guest_uuid = self.request.query_params.get("guest_uuid")
-        queryset = Note.objects.all().order_by("-created_at")
-        if guest_uuid:
-            queryset = queryset.filter(user__id=guest_uuid)
-        return queryset
+        return Note.objects.filter(user=self.request.user).order_by("-created_at")
 
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return NoteCreateSerializer
+        return NoteSerializer
+
+    def perform_create(self, serializer):
+        user = self.request.user
+        mood_name = self.request.data.get('mood_name')
+
+        mood_obj = None
+        if mood_name:
+            try:
+                mood_obj = Mood.objects.get(name__iexact=mood_name)
+            except Mood.DoesNotExist:
+                raise ValidationError({'mood_name': f"Mood '{mood_name}' not found."})
+        
+        serializer.save(user=user, mood=mood_obj)
 
 class NoteDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    Handles GET, PUT, PATCH, and DELETE for a single note.
+    """
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
     permission_classes = [IsAuthenticated]
     lookup_field = "pk"
+
+class NoteMigrationAPIView(APIView):
+    """
+    Handles bulk saving of guest notes during user signup.
+    """
+    serializer_class = NoteMigrationSerializer
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        
+        user = request.user
+        validated_entries = serializer.validated_data['entries']
+        
+        success_count = 0
+        errors = []
+
+        for entry_data in validated_entries:
+            try:
+                mood_name = entry_data.pop('mood_name', None)
+                mood_obj = None
+                if mood_name:
+                    mood_obj = Mood.objects.get(name__iexact=mood_name)
+                
+                Note.objects.create(user=user, mood=mood_obj, **entry_data)
+                success_count += 1
+            except Mood.DoesNotExist:
+                errors.append(f"Mood '{mood_name}' not found for entry '{entry_data.get('note')}'.")
+            except Exception as e:
+                errors.append(f"Error saving entry '{entry_data.get('note')}': {str(e)}")
+
+        response_data = {
+            "message": f"Migration complete. {success_count} entries saved.",
+            "success_count": success_count,
+            "errors": errors,
+        }
+        
+        return Response(response_data, status=status.HTTP_201_CREATED)

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -11,6 +11,7 @@ class CustomUser(AbstractUser):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     username = models.CharField(max_length=150, unique=True, blank=True, null=True)
+    is_guest = models.BooleanField(default=False)  # <-- This line was missing
 
     def __str__(self):
         return self.username or str(self.id)


### PR DESCRIPTION
### Summary of Changes

This PR introduces the backend endpoints for saving journal entries and migrating guest data.

- **New Endpoints:**
  - `POST /api/v1/notes/` for single entry creation.
  - `POST /api/v1/notes/migrate/` for bulk entry migration.
- **Permissions:** All new endpoints are protected with `IsAuthenticated`.
- **Validation:** Includes validation for mood names and bulk data structure.

---
Closes #41