### PR TITLE
Add /me Endpoint for User Profile

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -8,7 +8,8 @@ User = get_user_model()
 class CustomUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = CustomUser
-        fields = ["id", "username", "email"]
+        fields = ["id", "username", "email", "first_name", "last_name"]
+        read_only_fields = ["id", "username", "email"]
 
 
 class SignUpSerializer(serializers.ModelSerializer):

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -3,9 +3,11 @@ from .views import (
     LogoutView,
     SignUpView,
     LoginView,
+    UserMeView
 )
 
 urlpatterns = [
+    path("me/", UserMeView.as_view(), name="user_me"),
     path("login/", LoginView.as_view(), name="user_login"),
     path("logout/", LogoutView.as_view(), name="user_logout"),
     path("signup/", SignUpView.as_view(), name="user_signup"),

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -9,6 +9,14 @@ from .models import CustomUser
 from .serializers import SignUpSerializer, CustomUserSerializer
 
 
+class UserMeView(generics.RetrieveUpdateAPIView):
+    serializer_class = CustomUserSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_object(self):
+        return self.request.user
+
+
 class LoginView(ObtainAuthToken):
     """
     Custom login view to obtain auth token.


### PR DESCRIPTION
## Summary
This PR introduces a new /me endpoint that allows authenticated users to retrieve and update their profile information. It leverages DRF’s RetrieveUpdateAPIView for simplicity and security.

## ✅ Deliverables

- Added  first_name, and last_name fields in existing Serializer.

- Added MeView with RetrieveUpdateAPIView bound to request.user.

- Registered new route `/me/` in users/urls.py.

## Endpoint supports:

- `GET /me/` → fetch current user profile

- `PATCH /me/` → update first and last name (email optional if allowed)

## 📌 Notes

- id and email are read-only by default.

- Protected with `IsAuthenticated`.

- Keeps implementation minimal and reusable.