### PR TITLE
Switch to Email-Based Authentication

### DIFF
--- a/backend/users/admin.py
+++ b/backend/users/admin.py
@@ -13,7 +13,6 @@ class CustomUserAdmin(BaseUserAdmin):
     # The list_display controls which fields are shown in the user list view.
     # You might want to add 'id' here too.
     list_display = (
-        "username",
         "email",
         "id",
         "is_staff",

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -1,7 +1,33 @@
 # backend/users/models.py
 import uuid
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
+
+
+class CustomUsermanager(BaseUserManager):
+    def create_user(self, email, password, **extra_fields):
+        if not email:
+            raise ValueError("Email field must be set")
+
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        """
+        Create and return a superuser with the given email and password.
+        """
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
+
+        return self.create_user(email, password, **extra_fields)
 
 
 class CustomUser(AbstractUser):
@@ -10,7 +36,15 @@ class CustomUser(AbstractUser):
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    username = models.CharField(max_length=150, unique=True, blank=True, null=True)
+    username = models.CharField(max_length=150, blank=True, null=True)
+    email = models.EmailField(unique=True)
+    first_name = models.CharField(max_length=150)
+    last_name = models.CharField(max_length=150)
+
+    objects = CustomUsermanager()
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = []
 
     def __str__(self):
-        return self.username or str(self.id)
+        return self.get_full_name() or str(self.id)

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -8,24 +8,22 @@ User = get_user_model()
 class CustomUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = CustomUser
-        fields = ["id", "username", "email", "first_name", "last_name"]
-        read_only_fields = ["id", "username", "email"]
+        fields = ["id", "email", "first_name", "last_name"]
+        read_only_fields = ["id", "email"]
 
 
 class SignUpSerializer(serializers.ModelSerializer):
-    username = serializers.CharField()
     password = serializers.CharField(write_only=True, min_length=8)
 
     class Meta:
         model = User
-        fields = ("username", "email", "first_name", "last_name", "password")
+        fields = ("email", "first_name", "last_name", "password")
 
     def create(self, validated_data):
         user = User(
-            username=validated_data["username"],
-            email=validated_data.get("email", ""),
-            first_name=validated_data.get("first_name", ""),
-            last_name=validated_data.get("last_name", ""),
+            email=validated_data["email"],
+            first_name=validated_data["first_name"],
+            last_name=validated_data["last_name"],
         )
         user.set_password(validated_data["password"])
         user.save()


### PR DESCRIPTION
## Summary

This PR removes the username requirement during signup and updates serializers so authentication is handled by email instead of username.

## ✅ Deliverables

- Added `CustomUserManager` to override username default.

- Removed username field from signup and login.

- Signup now requires email + password with first/last name.

## 🔄 Outcome

- Superusers/admins can still be created normally with `createsuperuser` (email as identifier).

- API signup no longer asks for username.

- Users log in with email + password.