### PR TITLE
Fix login to accept email authentication

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,8 +1,31 @@
 from rest_framework import serializers
 from .models import CustomUser
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, authenticate
 
 User = get_user_model()
+
+
+class EmailAuthTokenSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        email = data.get("email")
+        password = data.get("password")
+
+        if email and password:
+            # Note: The 'authenticate' function is called with 'email' instead of 'username'.
+            user = authenticate(
+                request=self.context.get("request"), email=email, password=password
+            )
+
+            if not user:
+                raise serializers.ValidationError("Invalid credentials.")
+        else:
+            raise serializers.ValidationError("Both email and password are required.")
+
+        data["user"] = user
+        return data
 
 
 class CustomUserSerializer(serializers.ModelSerializer):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -6,7 +6,11 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from .models import CustomUser
-from .serializers import SignUpSerializer, CustomUserSerializer
+from .serializers import (
+    SignUpSerializer,
+    CustomUserSerializer,
+    EmailAuthTokenSerializer,
+)
 
 
 class UserMeView(generics.RetrieveUpdateAPIView):
@@ -23,6 +27,7 @@ class LoginView(ObtainAuthToken):
     """
 
     permission_classes = [AllowAny]
+    serializer_class = EmailAuthTokenSerializer
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(


### PR DESCRIPTION
## Summary

- Replaced default username login with email login for DRF token authentication.

- Added custom serializer and login view to handle email/password authentication.

- New endpoint /api/v1/auth/login/ now accepts { "email": ..., "password": ... }.