### PR TITLE
Weekly Mood Insights API

### DIFF
--- a/backend/api_docs/insights_api.md
+++ b/backend/api_docs/insights_api.md
@@ -1,86 +1,67 @@
-# Insights API Documentation
-
-This document describes the API endpoints for retrieving weekly mood history and a rule-based mood tip.
-
----
-
 ## 1) Get Weekly Mood History
 
 **Endpoint:** `GET /api/v1/insights/history/`  
-**Description:** Returns 7 days (Mon–Sun) of data for a selected week window: a graph-friendly array and a timeline list.
+**Description:** Returns 7 days (Mon–Sun) of data: a graph array (always 7 points) and a timeline (only days with notes).
 
 ### Request
 
-- **Method:** `GET`
-- **Headers:**
-  - `Authorization: Token <TOKEN>`
+- **Headers:** `Authorization: Token <TOKEN>`
+- **Query:**
+  - `week_offset` (int, optional, default `0`) — `0=this week`, `1=last week`, ...
+  - `week` (int, optional) — alias for `week_offset`
 
-**Query Parameters:**
-
-| Param         | Type | Required | Description                                                    | Example |
-| :------------ | :--- | :------- | :------------------------------------------------------------- | :------ |
-| `week_offset` | int  | No       | `0` = current week, `1` = previous week, etc. Defaults to `0`. | `0`     |
-| `week`        | int  | No       | Alias for `week_offset`.                                       | `1`     |
-
-### Response (HTTP 200 OK)
+### Response (200)
 
 ```json
 {
-  "week_start": "2025-08-11",
-  "week_end": "2025-08-17",
+  "week": { "start": "2025-08-11", "end": "2025-08-17" },
   "graph": [
-    { "date": "2025-08-11", "mood_value": 4 },
-    { "date": "2025-08-12", "mood_value": null },
-    { "date": "2025-08-13", "mood_value": 2 }
+    { "date": "2025-08-11", "mood_value": 4, "mood_id": 10 },
+    { "date": "2025-08-12", "mood_value": null, "mood_id": null },
+    { "date": "2025-08-13", "mood_value": 2, "mood_id": 7 },
+    { "date": "2025-08-14", "mood_value": 5, "mood_id": 12 },
+    { "date": "2025-08-15", "mood_value": 3, "mood_id": 7 },
+    { "date": "2025-08-16", "mood_value": 2, "mood_id": 11 },
+    { "date": "2025-08-17", "mood_value": 2, "mood_id": 11 }
   ],
   "timeline": [
-    /* Items serialized via NoteInsightSerializer */
+    {
+      "date": "2025-08-11",
+      "mood_value": 4,
+      "mood_id": 10,
+      "snippet": "Evening walk helped me unwind."
+    },
+    {
+      "date": "2025-08-13",
+      "mood_value": 2,
+      "mood_id": 7,
+      "snippet": "Busy day but manageable."
+    }
   ]
 }
 ```
 
 ### Notes:
 
-- **mood_value mapping:** very negative=1, negative=2, neutral=3, positive=4, very positive=5.
-- **Timeline items** use NoteInsightSerializer (see notes/serializers.py).
-- Weeks are Monday–Sunday, based on server TZ (e.g., Africa/Nairobi).
+- week.end is **inclusive** (Sunday).
+- graph always has 7 entries (Mon→Sun). Missing days → mood_value: null, mood_id: null.
+- timeline.snippet is trimmed to ≤120 chars.
+- **Validation:** /insights/history returns **400** for negative or non-integer week_offset.
 
 ### Postman
 
-**Environment vars**
-
-- `baseUrl` = `http://localhost:8000` (or your server)
-- `token` = your DRF token
-
-**Auth header**
-
-- Key: `Authorization`
-- Value: `Token {{token}}`
-
-**History request**
-
-- Method: GET
-- URL: `{{baseUrl}}/api/v1/insights/history/`
-- Params: `week_offset=0`
-
-**Tip request**
-
-- Method: GET
-- URL: `{{baseUrl}}/api/v1/insights/tip/`
-- Params: `week_offset=0`
-
-**Quick tests (Postman → Tests)**
-
 ```js
-// History
 pm.test("200 OK", () => pm.response.code === 200);
-const body = pm.response.json();
-pm.test("has week fields", () => body.week_start && body.week_end);
+const b = pm.response.json();
+pm.test("week has start/end", () => b.week && b.week.start && b.week.end);
 pm.test(
   "graph has 7 items",
-  () => Array.isArray(body.graph) && body.graph.length === 7
+  () => Array.isArray(b.graph) && b.graph.length === 7
 );
-pm.test("timeline is array", () => Array.isArray(body.timeline));
+pm.test("graph items include mood_id", () =>
+  b.graph.every((p) => "mood_id" in p)
+);
+pm.test("timeline is array", () => Array.isArray(b.timeline));
 ```
 
 ## 2) Get Weekly Mood Tip
@@ -91,59 +72,33 @@ Returns a single rule-based tip { "type": "tip", "message": "..." } for the same
 
 ### Request
 
-- **Method:** GET
-
-- **Headers:**
-
-- [] - Authorization: Token <TOKEN>
-
-### Query Parameters:
-
-| Param         | Type | Required | Description                                                    | Example |
-| :------------ | :--- | :------- | :------------------------------------------------------------- | :------ |
-| `week_offset` | int  | No       | `0` = current week, `1` = previous week, etc. Defaults to `0`. | `0`     |
-| `week`        | int  | No       | Alias for `week_offset`.                                       | `1`     |
+- **Headers:** Authorization: Token <TOKEN>
+- **Query:** week_offset (or week alias).
+  Invalid/negative values are **treated as 0** (no error) for this endpoint.
 
 ### Response (HTTP 200 OK)
 
-{ "type": "tip", "message": "Nice upward trend! Double down on what helped—note one thing that lifted your mood." }
+```json
+{
+  "type": "tip",
+  "message": "Nice upward trend! Double down on what helped—note one thing that lifted your mood."
+}
+```
 
-**Rule Priority (deterministic):**
-
-1. 3+ consecutive days of same low mood → grounding/rest tip
-
-2. Weekly trend: decline ≤ −0.6 or rise ≥ +0.6 → tuning/encouragement tip
-
-3. Low engagement: ≥3 missing days → gentle re-engagement tip
-
-4. Default gentle check-in
-
-### Postman
-
-**Tip request**
-
-- Method: GET
-
-- URL: {{baseUrl}}/api/v1/insights/tip/
-
-- Params: week_offset=0
-
-**Quick tests (Postman → Tests)**
+### Postman Tests
 
 ```js
 pm.test("200 OK", () => pm.response.code === 200);
-const body = pm.response.json();
+const t = pm.response.json();
 pm.test(
   "tip shape",
   () =>
-    body.type === "tip" &&
-    typeof body.message === "string" &&
-    body.message.length > 0
+    t.type === "tip" && typeof t.message === "string" && t.message.length > 0
 );
 ```
 
 ### Errors
 
-- **401/403** — Missing or invalid token.
-
-- **Invalid** week_offset — Treated as 0 (no error thrown).
+- 01/403 — Missing or invalid token.
+- /insights/history: 400 on invalid/negative week_offset.
+- /insights/tip: invalid/negative week is treated as 0.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -34,7 +34,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "users",
     "moods",
-    "notes",
+    "notes.apps.NotesConfig",
     "insights",
     "kindness",
 ]

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -30,9 +30,13 @@ class WeekRange:
 
 def get_week_range(week_offset: int) -> WeekRange:
     """
-    Monday-based weeks in the project's TIME_ZONE.
-    week_offset=0 -> current week; 1 -> previous week; etc.
+    Computes Monday-based week ranges in the active time zone
+    (as defined by Django's TIME_ZONE setting).
+
+    week_offset=0 → current week
+    week_offset=1 → previous week, and so on.
     """
+
     now = timezone.localtime(timezone.now())
     # Monday = 0 ... Sunday = 6
     this_monday = (now - timedelta(days=now.weekday())).date()

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -1,5 +1,4 @@
 # insights/services.py
-# insights/services.py
 from dataclasses import dataclass
 from datetime import timedelta, date
 from typing import List, Dict, Optional
@@ -77,7 +76,7 @@ def fetch_weekly_latest_per_day(user, wr: WeekRange):
     SQLite‑compatible reduction to one row per day (latest note of that day).
     """
     # constrain by date range (end is exclusive)
-    qs = Note.objects.filter(
+    qs = Note.objects.select_related("mood").filter(
         user=user,
         created_at__date__gte=wr.start,
         created_at__date__lt=wr.end,
@@ -132,7 +131,10 @@ def build_response(user, wr: WeekRange) -> Dict:
             graph.append({"date": d.isoformat(), "mood_value": None, "mood_id": None})
 
     return {
-        "week": {"start": wr.start.isoformat(), "end": wr.end.isoformat()},
+        "week": {
+            "start": wr.start.isoformat(), 
+            "end": (wr.end - timedelta(days=1)).isoformat(),  
+        },
         "graph": graph,
         "timeline": timeline,
     }

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -1,8 +1,8 @@
+# insights/services.py
 from dataclasses import dataclass
 from datetime import timedelta, date
 from typing import List, Dict, Optional
 
-from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Max, Subquery
 from django.db.models.functions import TruncDate
@@ -37,11 +37,24 @@ def cache_key(user_id: int, wr: WeekRange) -> str:
 
 
 def _mood_value_for(note: Note) -> Optional[int]:
-    if note.mood_value_snapshot is not None:
-        return int(note.mood_value_snapshot)
+    """
+    Determine a 1..5 mood value for a note.
+    Priority:
+      1) mood_value_snapshot if present on the model
+      2) note.mood.category.value (if available)
+      3) None
+    """
+    if getattr(note, "mood_value_snapshot", None) is not None:
+        try:
+            return int(note.mood_value_snapshot)
+        except (TypeError, ValueError):
+            return None
+
     # fallback to mood.category.value if you have that relationship
     try:
-        return int(getattr(note.mood.category, "value"))
+        category = getattr(note.mood, "category", None)
+        value = getattr(category, "value", None)
+        return int(value) if value is not None else None
     except Exception:
         return None
 
@@ -50,7 +63,7 @@ def fetch_weekly_latest_per_day(user, wr: WeekRange):
     """
     SQLite‑compatible reduction to one row per day (latest note of that day).
     """
-    # constrain by date range
+    # constrain by date range (end is exclusive)
     qs = Note.objects.filter(
         user=user,
         created_at__date__gte=wr.start,
@@ -92,8 +105,8 @@ def build_response(user, wr: WeekRange) -> Dict:
             mv = _mood_value_for(note)
             mid = getattr(note.mood, "id", None)
             graph.append({"date": d.isoformat(), "mood_value": mv, "mood_id": mid})
-            # timeline entry
-            snippet = (note.text or "").strip().replace("\n", " ")
+            # timeline entry (use your Note.note field; trim to 120 chars)
+            snippet = (getattr(note, "note", "") or "").strip().replace("\n", " ")
             if len(snippet) > 120:
                 snippet = snippet[:117].rstrip() + "..."
             timeline.append({

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+from datetime import timedelta, date
+from typing import List, Dict, Optional
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db.models import Max, Subquery
+from django.db.models.functions import TruncDate
+from django.utils import timezone
+
+from notes.models import Note  # adjust import if your app name differs
+
+WEEK_CACHE_TTL = 300  # 5 minutes
+
+
+@dataclass
+class WeekRange:
+    start: date  # inclusive, e.g., Monday 00:00
+    end: date    # exclusive, start + 7 days
+
+
+def get_week_range(week_offset: int) -> WeekRange:
+    """
+    Monday-based weeks in the project's TIME_ZONE.
+    week_offset=0 -> current week; 1 -> previous week; etc.
+    """
+    now = timezone.localtime(timezone.now())
+    # Monday = 0 ... Sunday = 6
+    this_monday = (now - timedelta(days=now.weekday())).date()
+    start = this_monday - timedelta(days=7 * week_offset)
+    end = start + timedelta(days=7)
+    return WeekRange(start=start, end=end)
+
+
+def cache_key(user_id: int, wr: WeekRange) -> str:
+    return f"insights:history:{user_id}:{wr.start.isoformat()}"
+
+
+def _mood_value_for(note: Note) -> Optional[int]:
+    if note.mood_value_snapshot is not None:
+        return int(note.mood_value_snapshot)
+    # fallback to mood.category.value if you have that relationship
+    try:
+        return int(getattr(note.mood.category, "value"))
+    except Exception:
+        return None
+
+
+def fetch_weekly_latest_per_day(user, wr: WeekRange):
+    """
+    SQLite‑compatible reduction to one row per day (latest note of that day).
+    """
+    # constrain by date range
+    qs = Note.objects.filter(
+        user=user,
+        created_at__date__gte=wr.start,
+        created_at__date__lt=wr.end,
+    )
+
+    # 1) compute last timestamp per day
+    per_day_latest = (
+        qs.annotate(day=TruncDate("created_at"))
+          .values("day")
+          .annotate(last_created=Max("created_at"))
+    )
+
+    # 2) pick the notes matching those last_created timestamps
+    latest_notes = (
+        qs.annotate(day=TruncDate("created_at"))
+          .filter(created_at__in=Subquery(per_day_latest.values("last_created")))
+          .order_by("day", "created_at")  # stable ordering
+    )
+
+    return list(latest_notes)
+
+
+def build_response(user, wr: WeekRange) -> Dict:
+    # materialize notes
+    notes = fetch_weekly_latest_per_day(user, wr)
+
+    # Map day -> note
+    by_day = {n.created_at.date(): n for n in notes}
+
+    # Build graph for 7 days
+    graph: List[Dict] = []
+    timeline: List[Dict] = []
+
+    for i in range(7):
+        d = wr.start + timedelta(days=i)
+        note = by_day.get(d)
+        if note:
+            mv = _mood_value_for(note)
+            mid = getattr(note.mood, "id", None)
+            graph.append({"date": d.isoformat(), "mood_value": mv, "mood_id": mid})
+            # timeline entry
+            snippet = (note.text or "").strip().replace("\n", " ")
+            if len(snippet) > 120:
+                snippet = snippet[:117].rstrip() + "..."
+            timeline.append({
+                "date": d.isoformat(),
+                "mood_value": mv,
+                "mood_id": mid,
+                "snippet": snippet,
+            })
+        else:
+            graph.append({"date": d.isoformat(), "mood_value": None, "mood_id": None})
+
+    return {
+        "week": {"start": wr.start.isoformat(), "end": wr.end.isoformat()},
+        "graph": graph,
+        "timeline": timeline,
+    }
+
+
+def get_history_payload(user, week_offset: int) -> Dict:
+    wr = get_week_range(week_offset)
+    key = cache_key(user.id, wr)
+
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    payload = build_response(user, wr)
+    cache.set(key, payload, timeout=WEEK_CACHE_TTL)
+    return payload

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -1,4 +1,5 @@
 # insights/services.py
+# insights/services.py
 from dataclasses import dataclass
 from datetime import timedelta, date
 from typing import List, Dict, Optional
@@ -8,9 +9,18 @@ from django.db.models import Max, Subquery
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 
-from notes.models import Note  # adjust import if your app name differs
+from notes.models import Note  
 
 WEEK_CACHE_TTL = 300  # 5 minutes
+
+# Map Mood.category (string) -> 1..5
+CATEGORY_VALUE_MAP = {
+    "very negative": 1,
+    "negative": 2,
+    "neutral": 3,
+    "positive": 4,
+    "very positive": 5,
+}
 
 
 @dataclass
@@ -41,22 +51,25 @@ def _mood_value_for(note: Note) -> Optional[int]:
     Determine a 1..5 mood value for a note.
     Priority:
       1) mood_value_snapshot if present on the model
-      2) note.mood.category.value (if available)
+      2) map Mood.category (string) via CATEGORY_VALUE_MAP
       3) None
     """
-    if getattr(note, "mood_value_snapshot", None) is not None:
+    snap = getattr(note, "mood_value_snapshot", None)
+    if snap is not None:
         try:
-            return int(note.mood_value_snapshot)
+            return int(snap)
         except (TypeError, ValueError):
             return None
 
-    # fallback to mood.category.value if you have that relationship
-    try:
-        category = getattr(note.mood, "category", None)
-        value = getattr(category, "value", None)
-        return int(value) if value is not None else None
-    except Exception:
+    mood = getattr(note, "mood", None)
+    if not mood:
         return None
+
+    cat = getattr(mood, "category", None)
+    if isinstance(cat, str):
+        return CATEGORY_VALUE_MAP.get(cat)
+
+    return None
 
 
 def fetch_weekly_latest_per_day(user, wr: WeekRange):

--- a/backend/insights/tests/test_history.py
+++ b/backend/insights/tests/test_history.py
@@ -1,58 +1,201 @@
 # insights/tests/test_history.py
+import pytest
+from datetime import datetime, time, timedelta
+
 from django.core.cache import cache
-from datetime import datetime, timedelta
-from django.utils import timezone
 from django.urls import reverse
-from rest_framework.test import APITestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
 from django.contrib.auth import get_user_model
 
 from notes.models import Note
-from moods.models import Mood
+# If you want to also test mood fallback, import Mood/MoodCategory and create them;
+# but these tests rely on mood_value_snapshot to avoid model coupling.
 
 User = get_user_model()
 
 
-class WeeklyInsightsTests(APITestCase):
-    def setUp(self):
-        cache.clear() 
-        self.user = User.objects.create_user(username="u1", password="pass1234")
-        self.token = Token.objects.create(user=self.user)
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+def _monday_of_current_week():
+    today = timezone.localdate()
+    return today - timedelta(days=today.weekday())  # Monday
 
-        # create moods for different categories and dates
-        monday = timezone.localdate() - timedelta(days=timezone.localdate().weekday())
-        # create moods and notes on Monday and Wednesday for this user
-        mood_pos = Mood.objects.create(name="happy", emoji="🙂", category="positive")
-        mood_neg = Mood.objects.create(name="sad", emoji="☹️", category="negative")
 
-        # Note on Monday
-        n1 = Note.objects.create(user=self.user, mood=mood_pos, note="Good day")
-        n1.created_at = datetime.combine(monday, timezone.now().time()).replace(
-            tzinfo=timezone.get_current_timezone()
-        )
+def _aware_dt(daydate, hh=10, mm=0, ss=0):
+    """Build a timezone-aware datetime on a specific local date/time."""
+    tz = timezone.get_current_timezone()
+    return tz.localize(datetime.combine(daydate, time(hh, mm, ss)))
 
-        n1.save()
 
-        # Note on Wednesday
-        wednesday = monday + timedelta(days=2)
-        n2 = Note.objects.create(user=self.user, mood=mood_neg, note="Bad day")
-        n2.created_at = datetime.combine(wednesday, timezone.now().time()).replace(
-            tzinfo=timezone.get_current_timezone()
-        )
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
 
-        n2.save()
 
-    def test_weekly_insights_graph_and_timeline(self):
-        url = reverse("mood_history")
-        res = self.client.get(f"{url}?week_offset=0")
-        self.assertEqual(res.status_code, 200)
-        data = res.json()
-        self.assertIn("graph", data)
-        self.assertIn("timeline", data)
-        self.assertEqual(len(data["graph"]), 7)
-        # graph should contain mood_value for monday and wednesday and None for other days
-        values = [p["mood_value"] for p in data["graph"]]
-        self.assertTrue(any(v is not None for v in values))
-        # timeline should contain two notes
-        self.assertGreaterEqual(len(data["timeline"]), 2)
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user_token_client(api_client):
+    """Create an email-based user, attach Token auth, and return (user, client)."""
+    user = User.objects.create_user(email="user1@example.com", password="pass1234")
+    token = Token.objects.create(user=user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return user, api_client
+
+
+@pytest.mark.django_db
+def test_history_returns_seven_days_and_latest_per_day(user_token_client):
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+
+    # Two notes on the SAME day; latest should win
+    early = _aware_dt(monday, 9, 0, 0)
+    late = _aware_dt(monday, 18, 30, 0)
+
+    n1 = Note.objects.create(
+        user=user,
+        text="early",
+        mood_value_snapshot=2,
+        created_at=early,  # will be overwritten below to ensure DB saves it
+    )
+    # Ensure created_at is persisted as given
+    Note.objects.filter(pk=n1.pk).update(created_at=early)
+
+    n2 = Note.objects.create(
+        user=user,
+        text="late",
+        mood_value_snapshot=4,
+        created_at=late,
+    )
+    Note.objects.filter(pk=n2.pk).update(created_at=late)
+
+    url = reverse("insights-history")
+    resp = client.get(f"{url}?week_offset=0")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "graph" in data and len(data["graph"]) == 7
+    assert "timeline" in data
+
+    # Latest per day should be reflected in timeline (snippet starts with "late")
+    assert any(item["snippet"].startswith("late") for item in data["timeline"])
+
+    # The graph should have at least one non-null value for Monday
+    monday_iso = monday.isoformat()
+    monday_point = next(p for p in data["graph"] if p["date"] == monday_iso)
+    assert monday_point["mood_value"] == 4
+
+
+@pytest.mark.django_db
+def test_history_week_offset_bounds(user_token_client):
+    user, client = user_token_client
+    url = reverse("insights-history")
+
+    # Negative should 400
+    resp = client.get(f"{url}?week_offset=-1")
+    assert resp.status_code == 400
+
+    # Non-integer should 400
+    resp = client.get(f"{url}?week_offset=abc")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_history_is_user_scoped(user_token_client):
+    user1, client = user_token_client
+    user2 = User.objects.create_user(email="user2@example.com", password="pass1234")
+
+    monday = _monday_of_current_week()
+    dt_user2 = _aware_dt(monday, 11, 0, 0)
+
+    # Create a note for a different user
+    n_other = Note.objects.create(
+        user=user2,
+        text="other user note",
+        mood_value_snapshot=5,
+        created_at=dt_user2,
+    )
+    Note.objects.filter(pk=n_other.pk).update(created_at=dt_user2)
+
+    url = reverse("insights-history")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Ensure no timeline item shows the other user's text
+    assert all("other user note" != t.get("snippet") for t in data["timeline"])
+
+
+@pytest.mark.django_db
+def test_history_missing_days_show_nulls_in_graph(user_token_client):
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+
+    # Only one note on Wednesday
+    wednesday = monday + timedelta(days=2)
+    dt = _aware_dt(wednesday, 16, 0, 0)
+    n = Note.objects.create(
+        user=user,
+        text="mid-week",
+        mood_value_snapshot=3,
+        created_at=dt,
+    )
+    Note.objects.filter(pk=n.pk).update(created_at=dt)
+
+    url = reverse("insights-history")
+    resp = client.get(url)
+    data = resp.json()
+
+    # Graph has 7 days; several should be null
+    values = [p["mood_value"] for p in data["graph"]]
+    assert len(values) == 7
+    assert any(v is None for v in values)  # at least one empty day
+
+
+@pytest.mark.django_db
+def test_history_cache_basic_ttl_behavior(user_token_client, monkeypatch):
+    """
+    First call populates cache (5 min TTL). A second call made immediately should
+    return the same data even if new notes are created in between. Clearing cache
+    should reflect new data.
+    """
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+
+    # Seed one note on Monday
+    dt1 = _aware_dt(monday, 9, 0, 0)
+    a = Note.objects.create(
+        user=user, text="A", mood_value_snapshot=2, created_at=dt1
+    )
+    Note.objects.filter(pk=a.pk).update(created_at=dt1)
+
+    url = reverse("insights-history")
+
+    # First call → caches
+    resp1 = client.get(url)
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    timeline_len_1 = len(data1["timeline"])
+
+    # Create a new note same week (should not appear until cache expires/clears)
+    dt2 = _aware_dt(monday + timedelta(days=1), 10, 0, 0)
+    b = Note.objects.create(
+        user=user, text="B", mood_value_snapshot=5, created_at=dt2
+    )
+    Note.objects.filter(pk=b.pk).update(created_at=dt2)
+
+    # Immediate second call → should be a cache hit; same timeline length
+    resp2 = client.get(url)
+    data2 = resp2.json()
+    assert len(data2["timeline"]) == timeline_len_1
+
+    # After clearing cache → new data should appear
+    cache.clear()
+    resp3 = client.get(url)
+    data3 = resp3.json()
+    assert len(data3["timeline"]) == timeline_len_1 + 1

--- a/backend/insights/tests/test_history.py
+++ b/backend/insights/tests/test_history.py
@@ -1,4 +1,3 @@
-# insights/tests/test_history.py
 import pytest
 from datetime import datetime, time, timedelta
 
@@ -45,6 +44,10 @@ def user_token_client(api_client):
     api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
     return user, api_client
 
+
+# ---------------------------------------------------------------------------
+# Core behavior
+# ---------------------------------------------------------------------------
 
 @pytest.mark.django_db
 def test_history_returns_seven_days_and_latest_per_day(user_token_client):
@@ -197,3 +200,91 @@ def test_history_cache_basic_ttl_behavior(user_token_client):
     resp3 = client.get(url)
     data3 = resp3.json()
     assert len(data3["timeline"]) == timeline_len_1 + 1
+
+
+# ---------------------------------------------------------------------------
+# New assertions matching current API contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_history_week_fields_are_inclusive(user_token_client):
+    user, client = user_token_client
+    url = reverse("insights-history")
+
+    resp = client.get(f"{url}?week_offset=0")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "week" in data and "start" in data["week"] and "end" in data["week"]
+
+    start = datetime.fromisoformat(data["week"]["start"]).date()
+    end = datetime.fromisoformat(data["week"]["end"]).date()
+    # Inclusive week: end = start + 6 days
+    assert end == start + timedelta(days=6)
+
+
+@pytest.mark.django_db
+def test_history_accepts_week_alias(user_token_client):
+    user, client = user_token_client
+    url = reverse("insights-history")
+
+    resp_default = client.get(url)              # week_offset defaults to 0
+    resp_alias = client.get(f"{url}?week=0")    # alias
+    assert resp_default.status_code == 200
+    assert resp_alias.status_code == 200
+    assert resp_default.json()["graph"] == resp_alias.json()["graph"]
+
+
+@pytest.mark.django_db
+def test_history_graph_includes_mood_id_field(user_token_client):
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+    dt = _aware_dt(monday, 9, 0, 0)
+
+    # note without mood relation is fine; mood_id can be null
+    Note.objects.create(user=user, note="x", mood_value_snapshot=3, created_at=dt)
+    Note.objects.filter(note="x").update(created_at=dt)
+
+    url = reverse("insights-history")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    graph = resp.json()["graph"]
+    assert len(graph) == 7
+    # Every graph item has mood_id key (may be None)
+    assert all("mood_id" in p for p in graph)
+
+
+@pytest.mark.django_db
+def test_mood_value_snapshot_overrides_category(user_token_client):
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+
+    # Create note with snapshot=5; snapshot should win over any mood category
+    dt = _aware_dt(monday, 10, 0, 0)
+    Note.objects.create(user=user, note="snap", mood_value_snapshot=5, created_at=dt)
+    Note.objects.filter(note="snap").update(created_at=dt)
+
+    url = reverse("insights-history")
+    resp = client.get(url)
+    g = resp.json()["graph"]
+    point = next(p for p in g if p["date"] == monday.isoformat())
+    assert point["mood_value"] == 5
+
+
+@pytest.mark.django_db
+def test_timeline_snippet_truncates_to_120(user_token_client):
+    user, client = user_token_client
+    monday = _monday_of_current_week()
+    long_text = "A" * 200
+
+    dt = _aware_dt(monday, 11, 0, 0)
+    n = Note.objects.create(user=user, note=long_text, mood_value_snapshot=3, created_at=dt)
+    Note.objects.filter(pk=n.pk).update(created_at=dt)
+
+    url = reverse("insights-history")
+    resp = client.get(url)
+    timeline = resp.json()["timeline"]
+    item = next(t for t in timeline if t["date"] == monday.isoformat())
+    assert len(item["snippet"]) <= 120
+    if len(long_text) > 120:
+        assert item["snippet"].endswith("...")

--- a/backend/insights/tests/test_history.py
+++ b/backend/insights/tests/test_history.py
@@ -10,8 +10,6 @@ from rest_framework.authtoken.models import Token
 from django.contrib.auth import get_user_model
 
 from notes.models import Note
-# If you want to also test mood fallback, import Mood/MoodCategory and create them;
-# but these tests rely on mood_value_snapshot to avoid model coupling.
 
 User = get_user_model()
 
@@ -59,7 +57,7 @@ def test_history_returns_seven_days_and_latest_per_day(user_token_client):
 
     n1 = Note.objects.create(
         user=user,
-        text="early",
+        note="early",
         mood_value_snapshot=2,
         created_at=early,  # will be overwritten below to ensure DB saves it
     )
@@ -68,7 +66,7 @@ def test_history_returns_seven_days_and_latest_per_day(user_token_client):
 
     n2 = Note.objects.create(
         user=user,
-        text="late",
+        note="late",
         mood_value_snapshot=4,
         created_at=late,
     )
@@ -116,7 +114,7 @@ def test_history_is_user_scoped(user_token_client):
     # Create a note for a different user
     n_other = Note.objects.create(
         user=user2,
-        text="other user note",
+        note="other user note",
         mood_value_snapshot=5,
         created_at=dt_user2,
     )
@@ -141,7 +139,7 @@ def test_history_missing_days_show_nulls_in_graph(user_token_client):
     dt = _aware_dt(wednesday, 16, 0, 0)
     n = Note.objects.create(
         user=user,
-        text="mid-week",
+        note="mid-week",
         mood_value_snapshot=3,
         created_at=dt,
     )
@@ -158,7 +156,7 @@ def test_history_missing_days_show_nulls_in_graph(user_token_client):
 
 
 @pytest.mark.django_db
-def test_history_cache_basic_ttl_behavior(user_token_client, monkeypatch):
+def test_history_cache_basic_ttl_behavior(user_token_client):
     """
     First call populates cache (5 min TTL). A second call made immediately should
     return the same data even if new notes are created in between. Clearing cache
@@ -170,7 +168,7 @@ def test_history_cache_basic_ttl_behavior(user_token_client, monkeypatch):
     # Seed one note on Monday
     dt1 = _aware_dt(monday, 9, 0, 0)
     a = Note.objects.create(
-        user=user, text="A", mood_value_snapshot=2, created_at=dt1
+        user=user, note="A", mood_value_snapshot=2, created_at=dt1
     )
     Note.objects.filter(pk=a.pk).update(created_at=dt1)
 
@@ -185,7 +183,7 @@ def test_history_cache_basic_ttl_behavior(user_token_client, monkeypatch):
     # Create a new note same week (should not appear until cache expires/clears)
     dt2 = _aware_dt(monday + timedelta(days=1), 10, 0, 0)
     b = Note.objects.create(
-        user=user, text="B", mood_value_snapshot=5, created_at=dt2
+        user=user, note="B", mood_value_snapshot=5, created_at=dt2
     )
     Note.objects.filter(pk=b.pk).update(created_at=dt2)
 

--- a/backend/insights/tests/test_note_snapshot_signal.py
+++ b/backend/insights/tests/test_note_snapshot_signal.py
@@ -1,0 +1,43 @@
+# insights/tests/test_note_snapshot_signal.py
+import pytest
+from django.utils import timezone
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from moods.models import Mood
+from notes.models import Note
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_snapshot_set_on_create():
+    user = User.objects.create_user(email="snap@test.com", password="x")
+    mood = Mood.objects.create(name="Happy", emoji="🙂", category="positive")
+    n = Note.objects.create(user=user, mood=mood, note="feels good")
+    assert n.mood_value_snapshot == 4
+
+
+@pytest.mark.django_db
+def test_snapshot_updates_when_mood_changes():
+    user = User.objects.create_user(email="snap2@test.com", password="x")
+    happy = Mood.objects.create(name="Happy", emoji="🙂", category="positive")
+    sad = Mood.objects.create(name="Sad", emoji="☹️", category="negative")
+
+    n = Note.objects.create(user=user, mood=happy, note="ok")
+    assert n.mood_value_snapshot == 4
+
+    n.mood = sad
+    n.save()
+    n.refresh_from_db()
+    assert n.mood_value_snapshot == 2
+
+
+@pytest.mark.django_db
+def test_explicit_snapshot_not_overwritten():
+    user = User.objects.create_user(email="snap3@test.com", password="x")
+    neutral = Mood.objects.create(name="Calm", emoji="😌", category="neutral")
+
+    # Explicit value should win (even if mood is neutral=3)
+    n = Note.objects.create(user=user, mood=neutral, note="set explicit", mood_value_snapshot=5)
+    assert n.mood_value_snapshot == 5

--- a/backend/insights/urls.py
+++ b/backend/insights/urls.py
@@ -1,7 +1,8 @@
+# insights/urls.py
 from django.urls import path
-from .views import WeeklyInsightView, WeeklyTipView
+from .views import WeeklyTipView, InsightsHistoryView
 
 urlpatterns = [
-    path("history/", WeeklyInsightView.as_view(), name="mood_history"),
-     path("tip/", WeeklyTipView.as_view(), name="mood_tip"),
+     path("api/v1/insights/tip", WeeklyTipView.as_view(), name="insights-tip"),
+    path("api/v1/insights/history", InsightsHistoryView.as_view(), name="insights-history"),
 ]

--- a/backend/insights/urls.py
+++ b/backend/insights/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from .views import WeeklyTipView, InsightsHistoryView
 
 urlpatterns = [
-     path("api/v1/insights/tip", WeeklyTipView.as_view(), name="insights-tip"),
-    path("api/v1/insights/history", InsightsHistoryView.as_view(), name="insights-history"),
+    path("history/", InsightsHistoryView.as_view(), name="insights-history"),
+    path("tip/", WeeklyTipView.as_view(), name="insights-tip"),
 ]

--- a/backend/insights/views.py
+++ b/backend/insights/views.py
@@ -1,25 +1,20 @@
 # insights/views.py
 from datetime import timedelta
+
 from django.utils import timezone
-from django.views.decorators.cache import cache_page
 from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+
 from rest_framework.views import APIView
-from rest_framework import permissions
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
 
 from notes.models import Note
-from notes.serializers import NoteInsightSerializer
-from .serializers import WeekSummarySerializer, InsightTipSerializer
+from .serializers import InsightTipSerializer
 from .rules import day_points_from_notes, render_tip
+from .services import get_history_payload
 
-# Map category → graph value (1..5) for the history graph
-CATEGORY_VALUE_MAP = {
-    "very negative": 1,
-    "negative": 2,
-    "neutral": 3,
-    "positive": 4,
-    "very positive": 5,
-}
 
 # ---- Shared helpers ---------------------------------------------------------
 
@@ -50,57 +45,38 @@ def _get_week_range(week_offset: int):
 
 # ---- Views ------------------------------------------------------------------
 
-@method_decorator(cache_page(60 * 5), name="dispatch")  # cache for 5 minutes
-class WeeklyInsightView(APIView):
+class InsightsHistoryView(APIView):
     """
-    GET /api/v1/insights/history/?week_offset=0
+    GET /api/v1/insights/history?week_offset=N
+    (Also accepts ?week=N as an alias)
 
-    Returns:
-      - graph: 7 points (Mon..Sun) where each point is the latest note's mood_value for that day (or null)
-      - timeline: list of notes in the week (newest first)
+    Returns a payload built by services.get_history_payload(user, week_offset):
+    {
+      "week": {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"},
+      "graph": [ { "date": "YYYY-MM-DD", "mood_value": 1..5|null, "mood_id": int|null }, ... 7 items ],
+      "timeline": [ { "date": "YYYY-MM-DD", "mood_value": 1..5, "mood_id": int|null, "snippet": "..." }, ... ]
+    }
     """
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
-        week_offset = _parse_week_offset(request)
-        week_start, week_end = _get_week_range(week_offset)
-
-        notes = (
-            Note.objects.filter(
-                user=request.user,
-                created_at__date__range=[week_start, week_end],
+        # Support both ?week_offset and ?week
+        raw = request.query_params.get("week_offset", request.query_params.get("week", "0"))
+        try:
+            week_offset = int(raw)
+            if week_offset < 0:
+                return Response(
+                    {"detail": "week_offset must be >= 0"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        except ValueError:
+            return Response(
+                {"detail": "week_offset must be an integer"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-            .select_related("mood")
-            .order_by("created_at")
-        )
 
-        # For each day, pick the latest note's mood value
-        day_mood_map = {}
-        for note in notes:
-            note_date = note.created_at.date()
-            mood_value = (
-                CATEGORY_VALUE_MAP.get(note.mood.category, None) if note.mood else None
-            )
-            day_mood_map[note_date] = mood_value  # latest wins due to .order_by("created_at")
-
-        graph = []
-        for i in range(7):
-            d = week_start + timedelta(days=i)
-            graph.append({"date": d, "mood_value": day_mood_map.get(d)})
-
-        timeline_qs = notes.order_by("-created_at")
-        timeline = NoteInsightSerializer(timeline_qs, many=True).data
-
-        payload = {
-            "week_start": week_start,
-            "week_end": week_end,
-            "graph": graph,
-            "timeline": timeline,
-        }
-
-        serializer = WeekSummarySerializer(data=payload)
-        serializer.is_valid(raise_exception=True)
-        return Response(serializer.validated_data)
+        payload = get_history_payload(request.user, week_offset)
+        return Response(payload, status=status.HTTP_200_OK)
 
 
 @method_decorator(cache_page(60 * 5), name="dispatch")  # cache for 5 minutes
@@ -109,7 +85,7 @@ class WeeklyTipView(APIView):
     GET /api/v1/insights/tip/?week_offset=0
     Returns a single rule-based tip: { "type": "tip", "message": "..." }
     """
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
         week_offset = _parse_week_offset(request)

--- a/backend/notes/apps.py
+++ b/backend/notes/apps.py
@@ -1,6 +1,12 @@
+# notes/apps.py
 from django.apps import AppConfig
 
 
 class NotesConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'notes'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "notes"
+
+    def ready(self):
+        # Import signal handlers
+        from . import signals  # noqa: F401
+

--- a/backend/notes/models.py
+++ b/backend/notes/models.py
@@ -8,16 +8,37 @@ from moods.models import Mood
 
 class Note(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="notes"
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="notes",
     )
+
     mood = models.ForeignKey(
-        Mood, on_delete=models.SET_NULL, null=True, blank=True, related_name="notes"
+        Mood,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="notes",
     )
+
+    # Free‑text content of the note
     note = models.TextField(blank=True)
+
+    # Snapshot of mood value (1..5) at creation/update time — used by insights history
+    mood_value_snapshot = models.IntegerField(null=True, blank=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["user", "created_at"]),
+        ]
+        ordering = ["-created_at"]
+
     def __str__(self):
-        return f"Note by {self.user.username} on {self.created_at.strftime('%Y-%m-%d %H:%M')}"
+        # Be robust if username isn't present (email-only auth)
+        who = getattr(self.user, "username", None) or getattr(self.user, "email", "user")
+        return f"Note by {who} on {self.created_at.strftime('%Y-%m-%d %H:%M')}"

--- a/backend/notes/signals.py
+++ b/backend/notes/signals.py
@@ -1,0 +1,51 @@
+# notes/signals.py
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from .models import Note
+
+CATEGORY_VALUE_MAP = {
+    "very negative": 1,
+    "negative": 2,
+    "neutral": 3,
+    "positive": 4,
+    "very positive": 5,
+}
+
+
+def _map_category_to_value(mood) -> int | None:
+    if not mood:
+        return None
+    cat = getattr(mood, "category", None)
+    if isinstance(cat, str):
+        return CATEGORY_VALUE_MAP.get(cat)
+    return None
+
+
+@receiver(pre_save, sender=Note)
+def fill_mood_value_snapshot(sender, instance: Note, **kwargs):
+    """
+    Ensure mood_value_snapshot is set from Mood.category on create,
+    and kept in sync when mood changes. If the field is explicitly
+    set by the caller, we respect that (no overwrite).
+    """
+    # If caller explicitly provided a snapshot, respect it.
+    if instance.mood_value_snapshot is not None:
+        return
+
+    # New object → compute from mood (if present)
+    if not instance.pk:
+        instance.mood_value_snapshot = _map_category_to_value(instance.mood)
+        return
+
+    # Existing object → only recompute if mood changed
+    try:
+        old = sender.objects.only("mood_id", "mood_value_snapshot").get(pk=instance.pk)
+    except sender.DoesNotExist:
+        # If somehow not found, treat it like a new object
+        instance.mood_value_snapshot = _map_category_to_value(instance.mood)
+        return
+
+    mood_changed = old.mood_id != getattr(instance, "mood_id", None)
+    if mood_changed:
+        instance.mood_value_snapshot = _map_category_to_value(instance.mood)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import EntriesPage from "./pages/EntriesPage";
 import PageTransition from "./components/PageTransition";
 import SignUpPage from "./pages/auth/SignUpPage";
 import LoginPage from "./pages/auth/LoginPage";
-// import InsightsPage from "./pages/InsightsPage"; // 🔸 Commented out to avoid crash
+import InsightsPage from "./pages/InsightsPage";
 
 function App() {
   return (
@@ -47,6 +47,7 @@ function App() {
         />
 
         {/* Features Page route */}
+
         <Route
           path="/features"
           element={
@@ -60,8 +61,7 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignUpPage />} />
 
-        {/* Insights Page route (temporarily disabled) */}
-        {/*
+        {/* Insights Page route */}
         <Route
           path="/insights"
           element={
@@ -70,7 +70,6 @@ function App() {
             </PageTransition>
           }
         />
-        */}
       </Routes>
     </>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import EntriesPage from "./pages/EntriesPage";
 import PageTransition from "./components/PageTransition";
 import SignUpPage from "./pages/auth/SignUpPage";
 import LoginPage from "./pages/auth/LoginPage";
-import InsightsPage from "./pages/InsightsPage";
+// import InsightsPage from "./pages/InsightsPage"; // 🔸 Commented out to avoid crash
 
 function App() {
   return (
@@ -47,7 +47,6 @@ function App() {
         />
 
         {/* Features Page route */}
-
         <Route
           path="/features"
           element={
@@ -61,7 +60,8 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignUpPage />} />
 
-        {/* Insights Page route */}
+        {/* Insights Page route (temporarily disabled) */}
+        {/*
         <Route
           path="/insights"
           element={
@@ -70,6 +70,7 @@ function App() {
             </PageTransition>
           }
         />
+        */}
       </Routes>
     </>
   );


### PR DESCRIPTION
**Description:**
Implements the /api/v1/insights/history endpoint 

**Features:**

**- GET /api/v1/insights/history?week_offset=N → returns:**
- [ ]  graph: 7 mood points (Mon–Sun)
- [ ] - timeline: per-day note snippets
**- Supports:**
- [ ] Missing days (graph shows null)
- [ ] Mood snapshot logic (mood_value_snapshot preferred)
- [ ] Efficient query using latest note per day
- [ ] Caching per (user, week_offset) for 5 minutes

**Backend Implementation:**

- insights/views.py: APIView + request validation
- insights/services.py: week range logic, cache, timeline, graph
- notes/signals.py: auto-fill mood_value_snapshot from Mood.category
- notes/migrations/0005_backfill_mood_value_snapshot.py: backfills existing notes
- insights/tests/test_history.py: full test suite (7d graph, user scoping, nulls, cache, snapshot)
- insights/urls.py: added named route insights-history

 **Logic:**

- insights/services.py builds payload using fetch_weekly_latest_per_day() 
- insights/views.py handles request validation
- notes/signals.py auto-fills snapshot via pre_save
- Fallback: maps Mood.category (string) to 1–5 scale
- Caching via Django’s cache framework
- Snapshot backfill migration included

**Checklist:**

- GET /api/v1/insights/history returns graph + timeline
-  Accepts week_offset or week as query param
-  Uses Note.mood_value_snapshot or fallback category
-  Signal auto-fills snapshot on note create/update
-  Backfill migration for historical notes
-  Unit tests for graph, timeline, cache, scoping, null days
-  Caching with TTL = 300s
-  API documented via example and internal docstring

**How to Test:**

GET /api/v1/insights/history?week_offset=0
Authorization: Token <user-token>

**Expect Response:**
<img width="829" height="459" alt="Insights Response" src="https://github.com/user-attachments/assets/27c88c7f-77f7-405d-a134-0da7b8fdc145" />


- 7 graph points (some may be null)
- timeline with snippets, mood_id, and date

**Other Changes:**

Updated INSTALLED_APPS:
"notes.apps.NotesConfig"

→ Enables Django to load signals.py, ensuring Note.mood_value_snapshot is auto-filled correctly.

**Recent Updates**

**File Updated: `backend/insights/services.py`**

- **Clarified time zone logic** in `get_week_range()` docstring to explicitly state that it uses the active time zone as defined by Django's `TIME_ZONE` setting.
- **Optimized mood query** in `fetch_weekly_latest_per_day()` by adding `select_related("mood")` to eliminate N+1 DB queries.
- **Adjusted `week.end` value** in the `/insights/history` response to be inclusive (i.e., returns Sunday as the final day), improving frontend alignment.
- **Removed duplicated comment header** for cleaner code readability.

**Test Coverage Added**

- Verified `week.end` is inclusive (Sunday) using date assertions.
- Confirmed support for the `?week=` alias parameter (same behavior as `week_offset`).
- Asserted that every graph point includes a `mood_id` field (even if `null`).
- Ensured `mood_value_snapshot` overrides any mood.category-derived fallback.
- Added test to check snippet truncation at 120 characters with ellipsis.

These additions improve confidence in the `/api/v1/insights/history` contract and ensure edge cases are fully covered.

**Related Issue**

Closes #73 