### PR TITLE
fix(notes): set mood_value_snapshot during note creation and migration

### DIFF
--- a/backend/notes/views.py
+++ b/backend/notes/views.py
@@ -42,7 +42,9 @@ class NoteListCreateAPIView(generics.ListCreateAPIView):
             except Mood.DoesNotExist:
                 raise ValidationError({"mood_name": f"Mood '{mood_name}' not found."})
 
-        serializer.save(user=user, mood=mood_obj)
+        mood_value_snapshot = mood_obj.category_value if mood_obj else None
+        serializer.save(user=user, mood=mood_obj, mood_value_snapshot=mood_value_snapshot)
+
 
     def create(self, request, *args, **kwargs):
         """
@@ -109,6 +111,7 @@ class NoteMigrationAPIView(APIView):
                             mood=mood,
                             user=user,
                             created_at=entry_data.get("created_at"),
+                            mood_value_snapshot=mood.category_value,
                         )
                     )
                 except Mood.DoesNotExist:


### PR DESCRIPTION
This PR resolves Issue #94 
 by ensuring that the mood_value_snapshot field is consistently set when creating new notes.

### Changes

- NoteListCreateAPIView.perform_create() now sets mood_value_snapshot from mood’s category_value
- NoteMigrationAPIView.post() sets mood_value_snapshot during bulk creation

### Tested

- Manual POST request
- Guest migration with various moods

