### PR TITLE
Implement and secure the user profile endpoint

### DIFF
--- a/backend/api_docs/user_api.md
+++ b/backend/api_docs/user_api.md
@@ -10,11 +10,7 @@
 ### Update the authenticated user’s profile details.
 - Only first_name and last_name can be updated.
 
-```✅ Request Body (JSON)
-{
-  "last_name": "Doe"
-}
-#### ✅ Request Body (JSON)
+```json
 {
   "last_name": "Doe"
 }

--- a/backend/api_docs/user_api.md
+++ b/backend/api_docs/user_api.md
@@ -1,0 +1,20 @@
+## 1. 👤 GET /api/v1/auth/me/
+
+### Retrieve the authenticated user’s profile details.
+
+- Requires a valid authentication token.
+
+
+## 2. ✏️ PATCH /api/v1/auth/me/
+
+### Update the authenticated user’s profile details.
+- Only first_name and last_name can be updated.
+
+```✅ Request Body (JSON)
+{
+  "last_name": "Doe"
+}
+#### ✅ Request Body (JSON)
+{
+  "last_name": "Doe"
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,6 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 python-dateutil==2.9.0.post0
 python-decouple==3.8
-python-ipware==3.0.0
 redis==6.4.0
 rq==2.6.0
 six==1.17.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ croniter==1.4.1
 distro==1.9.0
 Django==5.2.1
 django-cors-headers==4.7.0
+django-ipware==7.0.1
 django-redis==6.0.0
 django-rq==3.1
 djangorestframework==3.16.0
@@ -20,6 +21,7 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 python-dateutil==2.9.0.post0
 python-decouple==3.8
+python-ipware==3.0.0
 redis==6.4.0
 rq==2.6.0
 six==1.17.0

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -34,6 +34,23 @@ class CustomUserSerializer(serializers.ModelSerializer):
         fields = ["id", "email", "first_name", "last_name"]
         read_only_fields = ["id", "email"]
 
+    def validate_first_name(self, value):
+        return value.strip() if value else value
+
+    def validate_last_name(self, value):
+        return value.strip() if value else value
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        if request and request.method in ["PUT", "PATCH"]:
+            # Prevent email updates via this serializer
+            if "email" in request.data:
+                raise serializers.ValidationError({"email": "Email cannot be updated."})
+            if "id" in request.data:
+                raise serializers.ValidationError({"id": "ID cannot be updated."})
+
+        return super().validate(attrs)
+
 
 class SignUpSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=8)

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,3 +1,67 @@
-from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from rest_framework.authtoken.models import Token
 
-# Create your tests here.
+User = get_user_model()
+
+
+class MeEndpointTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="strongpassword123",
+            first_name="Old",
+            last_name="Name",
+        )
+        self.token = Token.objects.create(user=self.user)
+        self.url = reverse("user_me")
+
+    def authenticate(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+    def test_requires_authentication(self):
+        """Guests should be denied access"""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_retrieve_profile(self):
+        """Authenticated user should retrieve their profile"""
+        self.authenticate()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["email"], self.user.email)
+        self.assertEqual(response.data["first_name"], "Old")
+        self.assertEqual(response.data["last_name"], "Name")
+        self.assertIn("id", response.data)
+
+    def test_update_profile_valid(self):
+        """User can update first and last name"""
+        self.authenticate()
+        payload = {"first_name": "New", "last_name": "Person"}
+        response = self.client.put(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "New")
+        self.assertEqual(self.user.last_name, "Person")
+
+    def test_partial_update_profile(self):
+        """PATCH should allow updating only one field"""
+        self.authenticate()
+        payload = {"first_name": "Partial"}
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Partial")
+        self.assertEqual(self.user.last_name, "Name")  # unchanged
+
+    def test_invalid_fields_rejected(self):
+        """Ensure unexpected fields raise validation error"""
+        self.authenticate()
+        payload = {"email": "hacker@example.com"}  # not updatable here
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)


### PR DESCRIPTION
## 📌 PR: Implement User Profile GET & UPDATE Endpoint (/api/me)

### Summary

- Improved `/api/v1/auth/me endpoint` for authenticated users.

- Supports GET (profile retrieval) and PUT/PATCH (update first & last name).

- Enforces input length, trims whitespace, and raises errors for invalid payloads.

- Authentication required.

- Includes docs and tests.