### PR TITLE
fix(urls): prefix kindness messages with /api/v1 to match frontend

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -29,6 +29,6 @@ urlpatterns = [
     path("api/v1/insights/", include("insights.urls")),
     path('api/v1/notes/migrate/', NoteMigrationAPIView.as_view(), name='notes-migrate'),
     path("django-rq/", include("django_rq.urls")),
-    path("messages/", include("kindness.urls")),
+    path("api/v1/messages/", include("kindness.urls")),
     path("api/v1/contact/", include("contact.urls")),
 ]

--- a/backend/kindness/tests/test_kindness.py
+++ b/backend/kindness/tests/test_kindness.py
@@ -3,7 +3,6 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase, APIClient
 
-# Prefer Token auth; fall back to force_authenticate if authtoken isn't available
 USE_TOKEN = True
 try:
     from rest_framework.authtoken.models import Token
@@ -21,13 +20,21 @@ User = get_user_model()
 
 class KindnessEndpointTests(APITestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="linet", password="pass123")
         self.client = APIClient()
+
+        # Build kwargs that satisfy your CustomUser manager/model
+        create_kwargs = {"email": "linet@example.com", "password": "pass123"}
+        # Only add username if the field exists on your CustomUser
+        if any(f.name == "username" for f in User._meta.get_fields()):
+            create_kwargs["username"] = "linet"
+
+        self.user = User.objects.create_user(**create_kwargs)
+
         try:
             self.url = reverse("kindness:kindness-message")
         except Exception:
-            # Fallback if namespacing isn't configured
-            self.url = "/messages/kindness/"
+            # Match the new prefixed route
+            self.url = "/api/v1/messages/kindness/"
 
         if USE_TOKEN:
             token, _ = Token.objects.get_or_create(user=self.user)
@@ -37,42 +44,28 @@ class KindnessEndpointTests(APITestCase):
 
     # ---------- Helpers ----------
 
-    def _get_or_create_mood(
-        self,
-        name: str = "Neutral",
-        category: str = "neutral",
-        emoji: str = "😐",
-    ):
-        """
-        Create or retrieve a Mood that satisfies required fields on your model.
-        Ensures emoji and category are set even if the Mood existed already.
-        """
-        mood, _ = Mood.objects.get_or_create(
+    def _get_or_create_mood(self, name="Neutral", category="neutral", emoji="😐"):
+        mood, created = Mood.objects.get_or_create(
             name=name,
             defaults={"emoji": emoji, "category": category, "is_active": True},
         )
-        changed = False
-        if not getattr(mood, "emoji", None):
-            mood.emoji = emoji
-            changed = True
-        if not getattr(mood, "category", None):
-            mood.category = category
-            changed = True
-        if changed:
-            mood.save(update_fields=["emoji", "category"])
+        if not created:
+            changed = False
+            if not getattr(mood, "emoji", None):
+                mood.emoji = emoji
+                changed = True
+            if not getattr(mood, "category", None):
+                mood.category = category
+                changed = True
+            if changed:
+                mood.save(update_fields=["emoji", "category"])
         return mood
 
-    def _make_note(
-        self,
-        text: str = "test",
-        mood_name: str = "Neutral",
-        category: str = "neutral",
-        emoji: str = "😐",
-    ):
+    def _make_note(self, text="test", mood_name="Neutral", category="neutral", emoji="😐"):
         mood = self._get_or_create_mood(mood_name, category, emoji)
         return Note.objects.create(
             user=self.user,
-            mood=mood,  # FK instance, not an int
+            mood=mood,
             note=text,
             created_at=timezone.now(),
         )
@@ -85,37 +78,30 @@ class KindnessEndpointTests(APITestCase):
         self.assertEqual(resp.status_code, 401)
 
     def test_less_than_three_entries(self):
-        self._make_note(text="one", mood_name="Neutral", category="neutral", emoji="😐")
-        self._make_note(text="two", mood_name="Neutral", category="neutral", emoji="😐")
+        self._make_note(text="one")
+        self._make_note(text="two")
         resp = self.client.get(self.url)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(resp.data.get("no_message"))
 
     def test_success_then_cooldown_same_day(self):
         for txt in ("tired", "stressed", "grateful"):
-            self._make_note(
-                text=txt,
-                mood_name="Neutral",
-                category="neutral",
-                emoji="😐",
-            )
+            self._make_note(text=txt)
 
         resp1 = self.client.get(self.url)
         self.assertEqual(resp1.status_code, 200)
 
         if "message" in resp1.data:
-            # Happy path: a message was returned and logged
             self.assertTrue(resp1.data["message"])
             self.assertEqual(
                 KindnessMessageLog.objects.filter(user=self.user).count(), 1
             )
-            # Second call same day should be gated
             resp2 = self.client.get(self.url)
             self.assertEqual(resp2.status_code, 200)
             self.assertTrue(resp2.data.get("no_message"))
         else:
-            # If services are still stubbed or gated, both calls return no_message
             self.assertTrue(resp1.data.get("no_message"))
             resp2 = self.client.get(self.url)
             self.assertEqual(resp2.status_code, 200)
             self.assertTrue(resp2.data.get("no_message"))
+

--- a/backend/kindness/tests/test_kindness.py
+++ b/backend/kindness/tests/test_kindness.py
@@ -50,15 +50,18 @@ class KindnessEndpointTests(APITestCase):
             defaults={"emoji": emoji, "category": category, "is_active": True},
         )
         if not created:
-            changed = False
+            fields_to_update = []
+
             if not getattr(mood, "emoji", None):
                 mood.emoji = emoji
-                changed = True
+                fields_to_update.append("emoji")
+
             if not getattr(mood, "category", None):
                 mood.category = category
-                changed = True
-            if changed:
-                mood.save(update_fields=["emoji", "category"])
+                fields_to_update.append("category")  # <-- fix here
+
+            if fields_to_update:
+                mood.save(update_fields=fields_to_update)
         return mood
 
     def _make_note(self, text="test", mood_name="Neutral", category="neutral", emoji="😐"):
@@ -104,4 +107,3 @@ class KindnessEndpointTests(APITestCase):
             resp2 = self.client.get(self.url)
             self.assertEqual(resp2.status_code, 200)
             self.assertTrue(resp2.data.get("no_message"))
-


### PR DESCRIPTION
Closes #108 

- config/urls.py: add `path("api/v1/messages/", include("kindness.urls"))`
- kindness/urls.py unchanged (still `kindness/` under the messages prefix)
- kindness/tests/test_kindness.py: (create CustomUser with email; fallback URL 
to /api/v1/messages/kindness)

How to test (Postman)
1) GET http://127.0.0.1:8000/api/v1/messages/kindness/
2) Header: Authorization: Token <TOKEN>
3) Expect { "message": ... } or { "no_message": true, ... } depending on threshold/cooldown.
