### PR TITLE
Fix/frontend profile update 134

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -15,7 +15,7 @@ export async function getUser() {
 // Update logged-in user
 export async function updateUser(updates) {
   try {
-    const res = await axios.put("/auth/me/", updates);
+    const res = await axios.patch("/auth/me/", updates);
     return res.data;
   } catch (err) {
     console.error("Failed to update user:", err.response?.data || err.message);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -157,7 +157,11 @@ export const AuthProvider = ({ children }) => {
 
   // Don't render children until auth state is initialized
   if (!isInitialized) {
-    return null;
+    return (
+      <div className="auth-loading">
+        <div className="loading-spinner">Loading...</div>
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -48,10 +48,10 @@ export default function ProfilePage() {
     setSaving(true);
     setError(null);
     try {
+      // removed email from updates
       const updates = {
         first_name: formData.firstName,
         last_name: formData.lastName,
-        email: formData.email,
       };
       const updated = await updateUser(updates);
       setUser(updated);
@@ -82,10 +82,10 @@ export default function ProfilePage() {
       };
       setFormData(newFormData);
 
+      // removed email from updates
       const updates = {
         first_name: newFormData.firstName,
         last_name: newFormData.lastName,
-        email: newFormData.email,
       };
 
       if (editingField === "password" && editValue.trim() !== "********") {


### PR DESCRIPTION
## Summary
This PR updates the user profile API to improve consistency and security.

## Changes
- Switched the profile update method from **PUT** to **PATCH** to allow partial updates without requiring the full payload.
- Removed the ability to update a user’s **email** through the profile endpoint. 

## Rationale
- `PATCH` better reflects the intended behavior of partial updates and simplifies client requests.

## Impact
- API consumers should now use `PATCH /profile` instead of `PUT /profile`.