### PR TITLE
Fix/frontend/guest kindness null return 

### DIFF
--- a/frontend/src/services/guestAiService.js
+++ b/frontend/src/services/guestAiService.js
@@ -1,24 +1,20 @@
+// src/services/guestAiService.js
 import axios from "../lib/axiosInstance";
 
 export async function requestGuestAI({ guest_id, mood_name, note_snippet }) {
   try {
+    // Centralize trimming logic 
     const trimmedSnippet = (note_snippet || "").slice(0, 300);
 
-    const response = await axios.post(
-      "/guest/encourage",
-      {
-        guest_id,
-        mood_name,
-        note_snippet: trimmedSnippet,
-      },
-      {
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    const response = await axios.post("/insights/guest/encourage", {
+      guest_id,
+      mood_name,
+      note_snippet: trimmedSnippet,
+    });
 
-    return response.data; // axios auto-parses JSON
+    return response.data; 
   } catch (err) {
     console.error("Guest kindness AI failed:", err);
-    return { detail: "error" }; // fallback
+    return null; 
   }
 }

--- a/frontend/src/utils/guestKindness.js
+++ b/frontend/src/utils/guestKindness.js
@@ -32,7 +32,7 @@ export const handleGuestKindness = async (
   let message = null;
   try {
     const guest_id = getOrCreateGuestId();
-    const note_snippet = entry.slice(0, 300); // trim to max length
+    const note_snippet = entry; // service handles trimming
     const mood_name = mood?.name || null;
 
     const result = await requestGuestAI({ guest_id, mood_name, note_snippet });


### PR DESCRIPTION
This PR improves the GuestKindness AI service by aligning its error handling and data processing with the logged-in AI flow.

Key changes:
- `requestGuestAI` now returns `null` in the catch block instead of an error object, ensuring consistent behavior across guest and logged-in flows.
- Left-truncation of `note_snippet` is centralized in the service (limit 300 characters), simplifying calling code and ensuring uniform input to the API.
- Updated the endpoint to the correct backend route: `/insights/guest/encourage/`.

These changes make the guest AI requests more robust, reduce unexpected errors in the UI, and centralize key preprocessing logic.

#141 