### PR TITLE
Fix/frontend navigation spinner blankpage 153

### DIFF
--- a/frontend/src/components/KindnessMessage.jsx
+++ b/frontend/src/components/KindnessMessage.jsx
@@ -1,15 +1,26 @@
 import { X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import "./KindnessMessage.css";
 
 export default function KindnessMessage({
   message = "You’re doing great ❤️",
   onDismiss,
 }) {
+  const navigate = useNavigate();
+
+  const handleDismiss = () => {
+    if (onDismiss) {
+      onDismiss(); // let parent handle closing modal
+    } else {
+      navigate("/entries"); // fallback if no handler
+    }
+  };
+
   return (
     <div className="fade kindness-popup">
       <p>{message}</p>
       <button
-        onClick={onDismiss}
+        onClick={handleDismiss}
         className="kindness-dismiss"
         aria-label="Close"
       >

--- a/frontend/src/components/MoodSelector.jsx
+++ b/frontend/src/components/MoodSelector.jsx
@@ -118,8 +118,7 @@ export default function MoodSelector({ onMoodSelect }) {
       </h2>
 
       {loading ? (
-        <div className="spinner-container">
-          <div className="spinner"></div>
+        <div>
           <p>Loading moods...</p>
         </div>
       ) : error ? (

--- a/frontend/src/components/NewEntryForm.jsx
+++ b/frontend/src/components/NewEntryForm.jsx
@@ -112,7 +112,7 @@ export default function NewEntryForm({ mood, onSubmit }) {
 
       {/* Guest messages */}
       {!isLoggedIn && showKindness && (
-        <KindnessMessage message={kindnessMessage} />
+        <KindnessMessage message={kindnessMessage} onDismiss={onSubmit} />
       )}
       {!isLoggedIn && showLoginPrompt && (
         <LoginPrompt onComplete={onSubmit} />
@@ -120,7 +120,7 @@ export default function NewEntryForm({ mood, onSubmit }) {
 
       {/* Logged-in messages */}
       {isLoggedIn && kindnessMessage && (
-        <KindnessMessage message={kindnessMessage}/>
+        <KindnessMessage message={kindnessMessage} onDismiss={onSubmit}/>
       )}
 
 

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -8,16 +8,16 @@ export default function ProtectedRoute({ children, requiredRole = null }) {
 
   // Show loading while checking auth state
   if (loading) {
-    return null;
+    return <div className="app-loading">Loading...</div>;
   }
 
   // Redirect to login if not authenticated
   if (!isAuthenticated) {
     return (
-      <Navigate 
-        to="/login" 
-        state={{ from: location }} 
-        replace 
+      <Navigate
+        to="/login"
+        state={{ from: location }}
+        replace
       />
     );
   }
@@ -25,10 +25,10 @@ export default function ProtectedRoute({ children, requiredRole = null }) {
   // Check for required role if specified
   if (requiredRole && !hasRole(requiredRole)) {
     return (
-      <Navigate 
-        to="/unauthorized" 
-        state={{ from: location, requiredRole }} 
-        replace 
+      <Navigate
+        to="/unauthorized"
+        state={{ from: location, requiredRole }}
+        replace
       />
     );
   }
@@ -42,7 +42,7 @@ export function GuestRoute({ children }) {
 
   // Show loading while checking auth state
   if (loading) {
-    return null;
+    return <div className="app-loading">Loading...</div>;
   }
 
   // Redirect to dashboard if already authenticated

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -157,9 +157,7 @@ export const AuthProvider = ({ children }) => {
 
   // Don't render children until auth state is initialized
   if (!isInitialized) {
-    return (
-      null
-    );
+    return <div className="app-loading">Loading...</div>;
   }
 
   return (

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -158,9 +158,7 @@ export const AuthProvider = ({ children }) => {
   // Don't render children until auth state is initialized
   if (!isInitialized) {
     return (
-      <div className="auth-loading">
-        <div className="loading-spinner">Loading...</div>
-      </div>
+      null
     );
   }
 


### PR DESCRIPTION
## 📖 Description  
This PR addresses multiple frontend UX issues that were causing inconsistent navigation and visual glitches:  

- **Navigation after kindness message**  
  - Guests and logged-in users were not redirected properly after dismissing the kindness message.  
  - ✅ Now dismissing always navigates back to the `/entries` page.  

- **Unnecessary loading spinner**  
  - A brief, weird spinner was appearing on all pages.

- **Blank-page effect on login/signup**  
  - Users occasionally saw a blank page after logging in.  
  - ✅ Added proper loading states in `AuthContext`, `ProtectedRoute`, and `GuestRoute` to prevent white screens.  

---

## 🛠️ Changes Made  
- Updated `KindnessMessage` to handle navigation internally (`navigate('/entries')`).  
- Added proper loading placeholders instead of returning `null` during auth and route checks.  
- Removed unnecessary global spinner and blank page effect on login. 
- Simplified page transition logic for smoother navigation.  

---

## 🎯 Outcome  
- Smooth navigation after kindness message dismissal.   
- No more blank white screens during login or signup.  
- Overall frontend flow feels more seamless and user-friendly.  


closes (#153 )