### PR TITLE
Fix/frontend navigation

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,6 +3,8 @@
 
 # Python virtual environment
 env/
+venv-drf/
+venv/
 
 # Python cache
 __pycache__/

--- a/frontend/src/pages/MoodJournalPage.jsx
+++ b/frontend/src/pages/MoodJournalPage.jsx
@@ -35,12 +35,9 @@ export default function MoodJournalPage() {
       <JournalModal isOpen={isModalOpen} onClose={handleCloseModal}>
         <NewEntryForm
           mood={selectedMood}
-          onSubmit={() => {
-            // No redirect here — just close modal
-            setIsModalOpen(false);
-            setSelectedMood(null);
-          }}
+          onSubmit={handleCloseModal}
         />
+
       </JournalModal>
     </>
   );


### PR DESCRIPTION
## 🐞 Fix: Redirect issue after dismissing kindness message on MoodJournalPage

### 🧩 Summary

This PR fixes a navigation issue where users who created a journal entry from the **Mood Journal flow** (selecting a mood → writing → dismissing kindness message) would get stuck on the mood selection screen instead of being redirected to the **Entries page**.

### 🚨 Problem

-   When dismissing the kindness message after saving an entry via the **MoodJournalPage**, the app closed the modal but didn’t navigate away.
-   This happened because the inline `onSubmit` handler only closed the modal (`setIsModalOpen(false)` and `setSelectedMood(null)`) without calling `navigate("/entries")`.

### 🧠 Root Cause

`KindnessMessage` triggers the `onDismiss` → `onSubmit` callback chain.
In the Mood Journal flow, `onSubmit` did not include navigation, unlike `handleCloseModal()` which already did.
Hence, users stayed stuck on the same page.

### ✅ Solution

-   Replaced the inline `onSubmit` handler in **MoodJournalPage.jsx** with the existing `handleCloseModal` function.
-   This ensures consistent behavior between the “Add Entry” flow and the “Mood Journal” flow:
    -   Modal closes
    -   Mood resets
    -   User navigates to `/entries`


closes (#171 )