### PR TITLE
Fix(moods): Fix timezone handling

### DIFF
--- a/backend/moods/views.py
+++ b/backend/moods/views.py
@@ -30,7 +30,7 @@ def get_last_modified(request, *args, **kwargs):
     # Return the later of the two, or now if no objects exist (safe fallback)
 
     # Use timezone-aware minimum datetime
-    min_dt = datetime.min.replace(tzinfo=timezone.utc)
+    min_dt = datetime.min.replace(tzinfo=timezone.get_current_timezone())
     last_modified = max(
         latest_mood if latest_mood else min_dt,
         latest_category if latest_category else min_dt,


### PR DESCRIPTION
This pull request makes a minor update to the timezone handling in the `get_last_modified` function to ensure consistency with the application's current timezone settings.

* Changed the default minimum datetime in `get_last_modified` from UTC to use the application's current timezone with `timezone.get_current_timezone()` in `backend/moods/views.py`.