### PR TITLE
Refactor Mood Components to Use Icon and Integrate Global Mood Context

### DIFF
--- a/frontend/src/api/moods.js
+++ b/frontend/src/api/moods.js
@@ -1,5 +1,5 @@
-import axios from "../lib/axiosInstance";
+// import axios from "../lib/axiosInstance";
 
-export const getMoods = () => {
-  return axios.get("/moods/");
-};
+// export const getMoods = () => {
+//   return axios.get("/moods/");
+// };

--- a/frontend/src/components/EntryCard.css
+++ b/frontend/src/components/EntryCard.css
@@ -2,7 +2,6 @@
 :root {
   --gray-light: #d1d5db;  /* backgrounds, hover states, open borders */
   --gray-medium: #9ca3af; /* secondary text, icons, subtle borders */
-  /* --gray-dark: #111827;   main text */
   --gray-hover: #f3f4f6;  /* softer hover backgrounds */
 }
 
@@ -56,7 +55,6 @@
 .entry-card-wrapper .date-box .day {
   font-size: 1.1rem;
   font-weight: bold;
-  /* color: var(--gray-dark); */
 }
 
 .entry-card-wrapper .date-box .month {
@@ -72,14 +70,13 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
-  /* color: var(--gray-dark); */
 }
 
 /* Mood styling */
 .entry-card-wrapper .emoji,
 .entry-card-wrapper .mood-img {
-  width: 36px;
-  height: 36px;
+  width: 28px;
+  height: 28px;
   object-fit: cover;
   border-radius: 50%;
 }

--- a/frontend/src/components/EntryCard.jsx
+++ b/frontend/src/components/EntryCard.jsx
@@ -75,9 +75,9 @@ export default function EntryCard({ entry }) {
         </div>
         <div className="mood-line">
           <span className="emoji">
-            {entry.imageUrl ? (
+            {entry.icon ? (
               <img
-                src={entry.imageUrl}
+                src={entry.icon}
                 alt={entry.name || "Mood"}
                 className="mood-img"
               />

--- a/frontend/src/components/MoodSelector.jsx
+++ b/frontend/src/components/MoodSelector.jsx
@@ -1,10 +1,10 @@
-// MoodSelector.jsx
 import { FaArrowUp, FaArrowDown } from "react-icons/fa";
-import { useEffect, useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import "./MoodSelector.css";
-import { getMoods } from "../api/moods";
 import { guestMoods } from "../data/guestMoods";
 import { useAuth } from "../context/AuthContext";
+import { useMoods } from "../context/MoodContext";
+import { useMoodHelpers } from "../utils/moodHelper";
 
 function MoodItem({ mood, disabled, selected, onSelect }) {
   return (
@@ -13,10 +13,12 @@ function MoodItem({ mood, disabled, selected, onSelect }) {
       onClick={() => onSelect(mood)}
       role="button"
       tabIndex={disabled ? -1 : 0}
-      onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onSelect(mood)}
+      onKeyDown={(e) =>
+        (e.key === "Enter" || e.key === " ") && onSelect(mood)
+      }
       aria-label={`Select mood ${mood.name}`}
     >
-      <img src={mood.imageUrl} alt={`Mood: ${mood.name}`} />
+      <img src={mood.icon} alt={`Mood: ${mood.name}`} />
       <p className="mood-label">{mood.name}</p>
     </div>
   );
@@ -41,46 +43,34 @@ function PaginationButtons({ page, totalPages, onPrev, onNext }) {
 
 export default function MoodSelector({ onMoodSelect }) {
   const { isAuthenticated: isLoggedIn } = useAuth();
+  const { getAllMoods } = useMoodHelpers();
+  const { loading: moodsLoading } = useMoods();
 
-
-  // guests get moods instantly, logged-in users fetch from API
-  const [moods, setMoods] = useState(isLoggedIn ? [] : guestMoods);
-  const [loading, setLoading] = useState(isLoggedIn);
-  const [error, setError] = useState(null);
   const [disabled, setDisabled] = useState(false);
-
+  const [selectedMood, setSelectedMood] = useState(null);
   const [page, setPage] = useState(0);
   const [animating, setAnimating] = useState(false);
-  const [selectedMood, setSelectedMood] = useState(null);
   const pageSize = 4;
 
-  useEffect(() => {
-    if (!isLoggedIn) return;
-
-    const loadMoods = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await getMoods();
-        setMoods(res.data.moods || []);
-      } catch (err) {
-        console.error("Error fetching moods:", err);
-        setError("Could not load moods. Please try again.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadMoods();
-  }, [isLoggedIn]);
-
+  const moods = isLoggedIn ? getAllMoods() : guestMoods;
   const totalPages = Math.ceil(moods.length / pageSize);
+  const startIndex = page * pageSize;
+  const visibleMoods = moods.slice(startIndex, startIndex + pageSize);
+
+  const handleSelect = useCallback(
+    (mood) => {
+      if (disabled) return;
+      setDisabled(true);
+      setSelectedMood(mood.id);
+      onMoodSelect(mood);
+    },
+    [disabled, onMoodSelect]
+  );
 
   const changePage = useCallback((newPage) => {
     setAnimating(true);
     setDisabled(false);
     setSelectedMood(null);
-
     setTimeout(() => {
       setPage(newPage);
       setAnimating(false);
@@ -97,19 +87,6 @@ export default function MoodSelector({ onMoodSelect }) {
     [page, changePage]
   );
 
-  const handleSelect = useCallback(
-    (mood) => {
-      if (disabled) return;
-      setDisabled(true);
-      setSelectedMood(mood.id);
-      onMoodSelect(mood);
-    },
-    [disabled, onMoodSelect]
-  );
-
-  const startIndex = page * pageSize;
-  const visibleMoods = moods.slice(startIndex, startIndex + pageSize);
-
   return (
     <div className="mood-selector">
       <h1 className="mood-header">How are you feeling today?</h1>
@@ -117,19 +94,16 @@ export default function MoodSelector({ onMoodSelect }) {
         You can pick a mood or just write — whatever feels right today.
       </h2>
 
-      {loading ? (
-        <div>
-          <p>Loading moods...</p>
-        </div>
-      ) : error ? (
-        <p className="mood-error-message">{error}</p>
-      ) : moods.length === 0 ? (
-        <p className="mood-empty-message">No moods available.</p>
-      ) : (
+      {isLoggedIn && moodsLoading && (
+        <p className="mood-loading-message">Loading moods...</p>
+      )}
+
+      {moods && moods.length > 0 ? (
         <>
           <div
-            className={`mood-grid ${animating ? "fade-out" : "fade-in"} ${disabled ? "disabled" : ""
-              }`}
+            className={`mood-grid ${animating ? "fade-out" : "fade-in"} ${
+              disabled ? "disabled" : ""
+            }`}
           >
             {visibleMoods.map((mood) => (
               <MoodItem
@@ -151,6 +125,10 @@ export default function MoodSelector({ onMoodSelect }) {
             />
           )}
         </>
+      ) : (
+        <div className="mood-empty-wrapper">
+          <p className="mood-empty-message">No moods available</p>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/data/guestMoods.js
+++ b/frontend/src/data/guestMoods.js
@@ -1,23 +1,103 @@
 // Static moods for guest users only
 export const guestMoods = [
-  { id: 1, name: "Warm", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589715/Warm_ospuu6.svg" },
-  { id: 2, name: "Annoyed", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615436/Annoyed_hmbpkc.svg" },
-  { id: 3, name: "Sad", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg" },
-  { id: 4, name: "Playful", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757616036/Playful_p18t2u.svg" },
-  { id: 5, name: "Neutral", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg" },
-  { id: 6, name: "Irritated", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757622539/Irritated_ybgvkv.svg" },
-  { id: 7, name: "Nervous", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757623110/Nervous_m9tm4q.svg" },
-  { id: 8, name: "Helpless", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757624218/Helpless_rmwyq8.svg" },
-  { id: 9, name: "Hurt", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661463/Hurt_ibzurx.svg" },
-  { id: 10, name: "Happy", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757659647/Happy_km0lhv.svg" },
-  { id: 11, name: "Frustrated", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589705/Frustated_xagicj.svg" },
-  { id: 12, name: "Excited", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589704/Excited_tgka5f.svg" },
-  { id: 13, name: "Lonely", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg" },
-  { id: 14, name: "Disbelief", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589703/Disbelief_cofhzn.svg" },
-  { id: 15, name: "Angry", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661818/Angry_xfltel.svg" },
-  { id: 16, name: "Confused", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Confused_vlone7.svg" },
-  { id: 17, name: "Embarassed", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Concerned_vofqgv.svg" },
-  { id: 18, name: "Dissapointed", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Disappointed_mhmhbm.svg" },
-  { id: 19, name: "Relieved", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660828/Relieved_m34pow.svg" },
-  { id: 20, name: "Sick", imageUrl: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757662446/Sick_dxzthr.svg" },
+  {
+    id: 1,
+    name: "Warm",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589715/Warm_ospuu6.svg",
+  },
+  {
+    id: 2,
+    name: "Annoyed",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615436/Annoyed_hmbpkc.svg",
+  },
+  {
+    id: 3,
+    name: "Sad",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg",
+  },
+  {
+    id: 4,
+    name: "Playful",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757616036/Playful_p18t2u.svg",
+  },
+  {
+    id: 5,
+    name: "Neutral",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg",
+  },
+  {
+    id: 6,
+    name: "Irritated",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757622539/Irritated_ybgvkv.svg",
+  },
+  {
+    id: 7,
+    name: "Nervous",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757623110/Nervous_m9tm4q.svg",
+  },
+  {
+    id: 8,
+    name: "Helpless",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757624218/Helpless_rmwyq8.svg",
+  },
+  {
+    id: 9,
+    name: "Hurt",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661463/Hurt_ibzurx.svg",
+  },
+  {
+    id: 10,
+    name: "Happy",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757659647/Happy_km0lhv.svg",
+  },
+  {
+    id: 11,
+    name: "Frustrated",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589705/Frustated_xagicj.svg",
+  },
+  {
+    id: 12,
+    name: "Excited",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589704/Excited_tgka5f.svg",
+  },
+  {
+    id: 13,
+    name: "Lonely",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg",
+  },
+  {
+    id: 14,
+    name: "Disbelief",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589703/Disbelief_cofhzn.svg",
+  },
+  {
+    id: 15,
+    name: "Angry",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661818/Angry_xfltel.svg",
+  },
+  {
+    id: 16,
+    name: "Confused",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Confused_vlone7.svg",
+  },
+  {
+    id: 17,
+    name: "Embarassed",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Concerned_vofqgv.svg",
+  },
+  {
+    id: 18,
+    name: "Dissapointed",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Disappointed_mhmhbm.svg",
+  },
+  {
+    id: 19,
+    name: "Relieved",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660828/Relieved_m34pow.svg",
+  },
+  {
+    id: 20,
+    name: "Sick",
+    icon: "https://res.cloudinary.com/dirn4gqky/image/upload/v1757662446/Sick_dxzthr.svg",
+  },
 ];

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import ScrollToTop from "./components/ScrollToTop";
 import { AuthProvider } from "./context/AuthContext";
-// import { MoodProvider } from "./context/MoodContext";
+import { MoodProvider } from "./context/MoodContext";
 import { EntriesProvider } from "./context/EntriesContext";
 import { BrowserRouter } from "react-router-dom";
 import "./styles/global.css";
@@ -13,11 +13,11 @@ ReactDOM.createRoot(document.getElementById("root")).render(
     <BrowserRouter>
       <ScrollToTop />
       <AuthProvider>
-        {/* <MoodProvider> */}
+        <MoodProvider>
           <EntriesProvider>
             <App />
           </EntriesProvider>
-        {/* </MoodProvider> */}
+        </MoodProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/frontend/src/utils/guestUtils.js
+++ b/frontend/src/utils/guestUtils.js
@@ -20,7 +20,7 @@ export const createGuestEntry = (payload) => ({
   title: payload.title,
   note: payload.note,
   name: payload.name || "",
-  imageUrl: payload.imageUrl || "",
+  icon: payload.icon || "",
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 });
@@ -30,7 +30,7 @@ export const formatGuestPayload = (note, mood, title) => ({
   title: title || "",
   note: note || "",
   name: mood?.name || "",
-  imageUrl: mood?.imageUrl || "",
+  icon: mood?.icon || "",
 });
 
 // Check if any guest entries exist


### PR DESCRIPTION
# Summary
This PR refactors mood-related components and data to standardize the usage of `icon` instead of `imageUrl` and integrates the global `MoodContext`. The app is wrapped in `MoodProvider` to make mood data accessible globally, ensuring consistent handling across all components.

# Key Updates
- Delete the old `moods.js` service
- Update `EntryCard` and `MoodSelector` to use `icon` instead of `imageUrl`
- Clean up unused CSS and adjust mood display sizes
- Refactor `MoodSelector` to use `useMoods` and `useMoodHelpers` for consistent mood retrieval
- Update guest data (`guestMoods.js`, `guestUtils.js`) to use `icon`
- Wrap the app in `MoodProvider` for global context access

# Files Modified
- `src/components/EntryCard.jsx`
- `src/components/EntryCard.css`
- `src/components/MoodSelector.jsx`
- `src/context/MoodContext.jsx`
- `src/utils/moodHelper.js`
- `src/data/guestMoods.js`
- `src/utils/guestUtils.js`

# Expected Outcome
- Mood data is handled consistently across the app
- Components use `icon` instead of `imageUrl`, simplifying logic
- MoodProvider makes mood context available globally
-  Tweak mood display sizes for entry cards

#174 
