### PR TITLE
Fix/frontend loggedin entry navigation 177

### DIFF
--- a/frontend/src/hooks/useEntrySubmit.js
+++ b/frontend/src/hooks/useEntrySubmit.js
@@ -49,21 +49,21 @@ export default function useEntrySubmit({
       setTitle("");
 
       if (isLoggedIn) {
-        console.log("Handling logged-in kindness...");
-        const message = await handleLoggedInKindness({
+        // pass raw stuff to helper
+        await handleLoggedInKindness({
           entry,
           mood,
           response,
           totalEntries: entries.length + 1,
           setKindnessMessage,
-          navigate,
+          // forceAi: true, // To test
         });
 
-        // ✅ If no kindness message was triggered, navigate immediately
-        if (!message) {
-          console.log("No kindness message triggered, navigating to entries...");
-          onSubmit();
-        }
+        setTimeout(() => {
+          console.log("Navigating to /entries after kindness delay");
+          onSubmit?.(); // close modal in parent
+          navigate("/entries");
+        }, 3000);
       } else {
         console.log("Handling guest kindness...");
         await handleGuestKindness(

--- a/frontend/src/hooks/useEntrySubmit.js
+++ b/frontend/src/hooks/useEntrySubmit.js
@@ -12,30 +12,44 @@ export default function useEntrySubmit({
   entries,
 }) {
   const navigate = useNavigate();
+
+  // Local input states
   const [title, setTitle] = useState("");
   const [entry, setEntry] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  // States for kindness/login messages
   const [showKindness, setShowKindness] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
   const [kindnessMessage, setKindnessMessage] = useState(null);
 
   const handleSubmit = async () => {
-    if (!entry.trim() && !mood) return;
+    if (!entry.trim() && !mood) {
+      console.log("Nothing to submit: entry and mood empty");
+      return;
+    }
 
     const payload = isLoggedIn
-      ? { title: title.trim() || null, note: entry.trim(), mood_id: mood?.id || null }
+      ? {
+        title: title.trim() || null,
+        note: entry.trim(),
+        mood_id: mood?.id || null,
+      }
       : formatGuestPayload(entry, mood, title);
+
+    console.log("Submitting payload:", payload);
 
     try {
       setSubmitting(true);
-      const response = await addEntry(payload);
+
+      const response = await addEntry(payload); // saves note and returns backend response
+      console.log("FULL response from addEntry:", response);
 
       setEntry("");
       setTitle("");
 
       if (isLoggedIn) {
-        // Run kindness logic
+        console.log("Handling logged-in kindness...");
         const message = await handleLoggedInKindness({
           entry,
           mood,
@@ -45,10 +59,13 @@ export default function useEntrySubmit({
           navigate,
         });
 
-        // 🟢 If no kindness message was triggered, navigate immediately
-        if (!message) onSubmit();
-
+        // ✅ If no kindness message was triggered, navigate immediately
+        if (!message) {
+          console.log("No kindness message triggered, navigating to entries...");
+          onSubmit();
+        }
       } else {
+        console.log("Handling guest kindness...");
         await handleGuestKindness(
           navigate,
           onSubmit,
@@ -59,18 +76,22 @@ export default function useEntrySubmit({
           mood
         );
       }
-
     } catch (err) {
-      console.error("Error saving entry:", err);
-      alert("Could not save your note.");
+      console.error(
+        "Error saving entry:",
+        err.response?.data || err.message || err
+      );
+      alert("Could not save your note. Check console for details.");
     } finally {
       setSubmitting(false);
     }
   };
 
   return {
-    title, setTitle,
-    entry, setEntry,
+    title,
+    setTitle,
+    entry,
+    setEntry,
     submitting,
     handleSubmit,
     showKindness,

--- a/frontend/src/hooks/useEntrySubmit.js
+++ b/frontend/src/hooks/useEntrySubmit.js
@@ -12,55 +12,43 @@ export default function useEntrySubmit({
   entries,
 }) {
   const navigate = useNavigate();
-
-  // Local input states
   const [title, setTitle] = useState("");
   const [entry, setEntry] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  // States for kindness/login messages
   const [showKindness, setShowKindness] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
   const [kindnessMessage, setKindnessMessage] = useState(null);
 
   const handleSubmit = async () => {
-    if (!entry.trim() && !mood) {
-      console.log("Nothing to submit: entry and mood empty");
-      return;
-    }
+    if (!entry.trim() && !mood) return;
 
     const payload = isLoggedIn
-      ? {
-          title: title.trim() || null,
-          note: entry.trim(),
-          mood_id: mood?.id || null,
-        }
+      ? { title: title.trim() || null, note: entry.trim(), mood_id: mood?.id || null }
       : formatGuestPayload(entry, mood, title);
-
-    console.log("Submitting payload:", payload);
 
     try {
       setSubmitting(true);
-
-      const response = await addEntry(payload); // saves note and returns backend response
-      console.log("FULL response from addEntry:", response);
+      const response = await addEntry(payload);
 
       setEntry("");
       setTitle("");
 
       if (isLoggedIn) {
-        // pass raw stuff to helper
-        await handleLoggedInKindness({
+        // Run kindness logic
+        const message = await handleLoggedInKindness({
           entry,
           mood,
           response,
           totalEntries: entries.length + 1,
           setKindnessMessage,
           navigate,
-          // forceAi: true, // To test
         });
+
+        // 🟢 If no kindness message was triggered, navigate immediately
+        if (!message) onSubmit();
+
       } else {
-        console.log("Handling guest kindness...");
         await handleGuestKindness(
           navigate,
           onSubmit,
@@ -71,22 +59,18 @@ export default function useEntrySubmit({
           mood
         );
       }
+
     } catch (err) {
-      console.error(
-        "Error saving entry:",
-        err.response?.data || err.message || err
-      );
-      alert("Could not save your note. Check console for details.");
+      console.error("Error saving entry:", err);
+      alert("Could not save your note.");
     } finally {
       setSubmitting(false);
     }
   };
 
   return {
-    title,
-    setTitle,
-    entry,
-    setEntry,
+    title, setTitle,
+    entry, setEntry,
     submitting,
     handleSubmit,
     showKindness,

--- a/frontend/src/utils/loggedInKindness.js
+++ b/frontend/src/utils/loggedInKindness.js
@@ -70,7 +70,6 @@ export const handleLoggedInKindness = async ({
       // navigate after short delay 
       setTimeout(() => {
         console.log("Navigating to /entries after kindness display");
-        navigate("/entries");
       }, 3000);
     } else {
       console.log("No message returned from backend.");


### PR DESCRIPTION
### Summary
This PR fixes the issue where logged-in users were not being redirected to the entries page after saving a new entry. The navigation call inside `handleLoggedInKindness` was not executing because `navigate` was no longer passed down to it.

### Changes
- Removed navigation responsibility from `handleLoggedInKindness`.
- Updated `useEntrySubmit` to handle post-kindness navigation after message display.
- Ensured smooth redirect flow for logged-in users with a short delay for kindness message visibility.

### Result
After submitting an entry:
1. The kindness message (if available) is shown.
2. After a brief delay, the app automatically navigates to `/entries`.

This restores expected behavior for logged-in users while keeping the kindness logic modular.

---
