### PR TITLE
Fix/frontend loggedin entry navigation issue 177

### DIFF
--- a/frontend/src/hooks/useEntrySubmit.js
+++ b/frontend/src/hooks/useEntrySubmit.js
@@ -31,10 +31,10 @@ export default function useEntrySubmit({
 
     const payload = isLoggedIn
       ? {
-          title: title.trim() || null,
-          note: entry.trim(),
-          mood_id: mood?.id || null,
-        }
+        title: title.trim() || null,
+        note: entry.trim(),
+        mood_id: mood?.id || null,
+      }
       : formatGuestPayload(entry, mood, title);
 
     console.log("Submitting payload:", payload);
@@ -57,6 +57,7 @@ export default function useEntrySubmit({
           totalEntries: entries.length + 1,
           setKindnessMessage,
           navigate,
+          onSubmit,
           // forceAi: true, // To test
         });
       } else {

--- a/frontend/src/utils/loggedInKindness.js
+++ b/frontend/src/utils/loggedInKindness.js
@@ -12,6 +12,7 @@ export const handleLoggedInKindness = async ({
   totalEntries,
   setKindnessMessage,
   navigate,
+  onSubmit,
   // forceAi = false, // mock test flag
 }) => {
   console.log("=== handleLoggedInKindness called ===");
@@ -69,11 +70,17 @@ export const handleLoggedInKindness = async ({
 
       // navigate after short delay 
       setTimeout(() => {
-        console.log("Navigating to /entries after kindness display");
+        console.log("Navigating to /entries after kindness delay");
+        onSubmit?.(); // close modal in parent
         navigate("/entries");
       }, 3000);
     } else {
       console.log("No message returned from backend.");
+      setTimeout(() => {
+        console.log("Navigating to /entries if after delay no message");
+        onSubmit?.(); // close modal in parent
+        navigate("/entries");
+      }, 2000);
     }
   } catch (err) {
     console.error("Error in handleLoggedInKindness:", err);


### PR DESCRIPTION
### Summary
This PR fixes the issue where logged-in users were not being redirected to the entries page after saving a new entry. The navigation call inside `handleLoggedInKindness` was not executing because `navigate` was no longer passed down to it.

- Handled the navigation logic in the loggedinkindness utility.

closes(#177 )