### PR TITLE
feat(insight): implement mood category numeric mapping and cache clea…

### DIFF
--- a/backend/insights/apps.py
+++ b/backend/insights/apps.py
@@ -2,5 +2,9 @@ from django.apps import AppConfig
 
 
 class InsightsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'insights'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "insights"
+
+    def ready(self):
+        # Import signal handlers
+        from . import signals  # noqa: F401

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -104,7 +104,7 @@ def _mood_value_for(note: Note) -> Optional[int]:
         cat_value = getattr(cat, "value", None)
 
         if isinstance(cat_value, str):
-            return CATEGORY_NUMERIC_MAPPING.get(cat_value.lower(), None)
+            return CATEGORY_NUMERIC_MAPPING.get(cat_value.lower())
     return None
 
 

--- a/backend/insights/services.py
+++ b/backend/insights/services.py
@@ -11,17 +11,9 @@ from django.db.models.functions import TruncDate
 from django.utils import timezone
 
 from notes.models import Note  # <-- needed for typing + queryset
+from moods.constants import CATEGORY_NUMERIC_MAPPING
 
 WEEK_CACHE_TTL = 604800  # 1 week
-
-# Map Mood.category (string) -> 1..5
-CATEGORY_VALUE_MAP = {
-    "very negative": 1,
-    "negative": 2,
-    "neutral": 3,
-    "positive": 4,
-    "very positive": 5,
-}
 
 
 @dataclass
@@ -92,7 +84,7 @@ def _mood_value_for(note: Note) -> Optional[int]:
     Determine a 1..5 mood value for a note.
     Priority:
       1) mood_value_snapshot if present on the model
-      2) map Mood.category (string) via CATEGORY_VALUE_MAP
+      2) map Mood.category (string) via CATEGORY_NUMERIC_MAPPING
       3) None
     """
     snap = getattr(note, "mood_value_snapshot", None)
@@ -107,9 +99,12 @@ def _mood_value_for(note: Note) -> Optional[int]:
         return None
 
     cat = getattr(mood, "category", None)
-    if isinstance(cat, str):
-        return cat  # Removing conversion to mood value here
 
+    if cat:
+        cat_value = getattr(cat, "value", None)
+
+        if isinstance(cat_value, str):
+            return CATEGORY_NUMERIC_MAPPING.get(cat_value.lower(), None)
     return None
 
 

--- a/backend/insights/signals.py
+++ b/backend/insights/signals.py
@@ -1,0 +1,33 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from datetime import date, timedelta
+from notes.models import Note
+from django.core.cache import cache
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def delete_user_week_cache(user_pk: int, week_start: date):
+    key = f"insights:history:{str(user_pk)}:{week_start.isoformat()}"
+    cache.delete(key)
+
+    logger.debug(
+        f"Cleared weekly insights cache for user {user_pk}, week starting {week_start}"
+    )
+
+
+@receiver(post_save, sender=Note)
+def clear_cache_on_note_save(sender, instance: Note, **kwargs):
+    user_pk = instance.user.pk
+    note_date = instance.created_at.date()
+    monday = note_date - timedelta(days=note_date.weekday())
+    delete_user_week_cache(user_pk, monday)
+
+
+@receiver(post_delete, sender=Note)
+def clear_cache_on_note_delete(sender, instance: Note, **kwargs):
+    user_pk = instance.user.pk
+    note_date = instance.created_at.date()
+    monday = note_date - timedelta(days=note_date.weekday())
+    delete_user_week_cache(user_pk, monday)

--- a/backend/moods/constants.py
+++ b/backend/moods/constants.py
@@ -15,3 +15,12 @@ CATEGORY_ICONS = {
     "negative": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg",
     "very negative": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg",
 }
+
+# Numeric mapping for categories (value: numeric_value)
+CATEGORY_NUMERIC_MAPPING = {
+    "very negative": 1,
+    "negative": 2,
+    "neutral": 3,
+    "positive": 4,
+    "very positive": 5,
+}

--- a/backend/moods/management/commands/seed_moods.py
+++ b/backend/moods/management/commands/seed_moods.py
@@ -1,45 +1,186 @@
 # backend/moods/management/commands/seed_moods.py
 from django.core.management.base import BaseCommand
-from moods.models import Mood, MoodCategory, CATEGORY_CHOICES # Import MoodCategory and CATEGORY_CHOICES
+from moods.models import Mood, MoodCategory
 from django.db import transaction
 
 # --- CATEGORY DATA (for MoodCategory model) ---
 CATEGORY_DATA = [
-    {"value": "very negative", "label": "Very Negative", "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg"},
-    {"value": "negative", "label": "Negative", "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg"},
-    {"value": "neutral", "label": "Neutral", "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg"},
-    {"value": "positive", "label": "Positive", "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757663590/Positive_yaegjw.svg"},
-    {"value": "very positive", "label": "Very Positive", "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757664397/Very_Positive_grjod4.svg"},
+    {
+        "value": "very negative",
+        "label": "Very Negative",
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg",
+    },
+    {
+        "value": "negative",
+        "label": "Negative",
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg",
+    },
+    {
+        "value": "neutral",
+        "label": "Neutral",
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg",
+    },
+    {
+        "value": "positive",
+        "label": "Positive",
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757663590/Positive_yaegjw.svg",
+    },
+    {
+        "value": "very positive",
+        "label": "Very Positive",
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757664397/Very_Positive_grjod4.svg",
+    },
 ]
 
 # --- MOOD DATA (for Mood model) ---
 MOODS_TO_SEED = [
-    {'name': 'Warm', 'emoji_char': '🔥', 'category_value': 'positive', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589715/Warm_ospuu6.svg'},
-    {'name': 'Annoyed', 'emoji_char': '😒', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757615436/Annoyed_hmbpkc.svg'},
-    {'name': 'Sad', 'emoji_char': '😔', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg'},
-    {'name': 'Playful', 'emoji_char': '😜', 'category_value': 'positive', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757616036/Playful_p18t2u.svg'},
-    {'name': 'Neutral', 'emoji_char': '😐', 'category_value': 'neutral', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg'},
-    {'name': 'Irritated', 'emoji_char': '😠', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757622539/Irritated_ybgvkv.svg'},
-    {'name': 'Nervous', 'emoji_char': '😬', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757623110/Nervous_m9tm4q.svg'},
-    {'name': 'Helpless', 'emoji_char': '😩', 'category_value': 'very negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757624218/Helpless_rmwyq8.svg'},
-    {'name': 'Hurt', 'emoji_char': '🤕', 'category_value': 'very negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757661463/Hurt_ibzurx.svg'},
-    {'name': 'Happy', 'emoji_char': '😃', 'category_value': 'positive', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757659647/Happy_km0lhv.svg'},
-    {'name': 'Frustrated', 'emoji_char': '😤', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589705/Frustated_xagicj.svg'},
-    {'name': 'Excited', 'emoji_char': '🤩', 'category_value': 'very positive', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589704/Excited_tgka5f.svg'},
-    {'name': 'Lonely', 'emoji_char': '😞', 'category_value': 'very negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg'},
-    {'name': 'Disbelief', 'emoji_char': '😲', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589703/Disbelief_cofhzn.svg'},
-    {'name': 'Angry', 'emoji_char': '😡', 'category_value': 'very negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757661818/Angry_xfltel.svg'},
-    {'name': 'Confused', 'emoji_char': '😕', 'category_value': 'neutral', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Confused_vlone7.svg'},
-    {'name': 'Embarrassed', 'emoji_char': '😳', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Concerned_vofqgv.svg'},
-    {'name': 'Disappointed', 'emoji_char': '😞', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Disappointed_mhmhbm.svg'},
-    {'name': 'Relieved', 'emoji_char': '😌', 'category_value': 'positive', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757660828/Relieved_m34pow.svg'},
-    {'name': 'Sick', 'emoji_char': '🤒', 'category_value': 'negative', 'is_active': True, 'icon': 'https://res.cloudinary.com/dirn4gqky/image/upload/v1757662446/Sick_dxzthr.svg'},
+    {
+        "name": "Warm",
+        "emoji_char": "🔥",
+        "category_value": "positive",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589715/Warm_ospuu6.svg",
+    },
+    {
+        "name": "Annoyed",
+        "emoji_char": "😒",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615436/Annoyed_hmbpkc.svg",
+    },
+    {
+        "name": "Sad",
+        "emoji_char": "😔",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757615267/Sad_vlwdhy.svg",
+    },
+    {
+        "name": "Playful",
+        "emoji_char": "😜",
+        "category_value": "positive",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757616036/Playful_p18t2u.svg",
+    },
+    {
+        "name": "Neutral",
+        "emoji_char": "😐",
+        "category_value": "neutral",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757617744/Neutral_j2n5gp.svg",
+    },
+    {
+        "name": "Irritated",
+        "emoji_char": "😠",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757622539/Irritated_ybgvkv.svg",
+    },
+    {
+        "name": "Nervous",
+        "emoji_char": "😬",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757623110/Nervous_m9tm4q.svg",
+    },
+    {
+        "name": "Helpless",
+        "emoji_char": "😩",
+        "category_value": "very negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757624218/Helpless_rmwyq8.svg",
+    },
+    {
+        "name": "Hurt",
+        "emoji_char": "🤕",
+        "category_value": "very negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661463/Hurt_ibzurx.svg",
+    },
+    {
+        "name": "Happy",
+        "emoji_char": "😃",
+        "category_value": "positive",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757659647/Happy_km0lhv.svg",
+    },
+    {
+        "name": "Frustrated",
+        "emoji_char": "😤",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589705/Frustated_xagicj.svg",
+    },
+    {
+        "name": "Excited",
+        "emoji_char": "🤩",
+        "category_value": "very positive",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589704/Excited_tgka5f.svg",
+    },
+    {
+        "name": "Lonely",
+        "emoji_char": "😞",
+        "category_value": "very negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660403/Lonely_bfgeld.svg",
+    },
+    {
+        "name": "Disbelief",
+        "emoji_char": "😲",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589703/Disbelief_cofhzn.svg",
+    },
+    {
+        "name": "Angry",
+        "emoji_char": "😡",
+        "category_value": "very negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757661818/Angry_xfltel.svg",
+    },
+    {
+        "name": "Confused",
+        "emoji_char": "😕",
+        "category_value": "neutral",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Confused_vlone7.svg",
+    },
+    {
+        "name": "Embarrassed",
+        "emoji_char": "😳",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Concerned_vofqgv.svg",
+    },
+    {
+        "name": "Disappointed",
+        "emoji_char": "😞",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757589702/Disappointed_mhmhbm.svg",
+    },
+    {
+        "name": "Relieved",
+        "emoji_char": "😌",
+        "category_value": "positive",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757660828/Relieved_m34pow.svg",
+    },
+    {
+        "name": "Sick",
+        "emoji_char": "🤒",
+        "category_value": "negative",
+        "is_active": True,
+        "icon": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757662446/Sick_dxzthr.svg",
+    },
 ]
 
 # ------------------------------------------
 
+
 class Command(BaseCommand):
-    help = 'Seeds the database with initial Mood Categories and Moods.'
+    help = "Seeds the database with initial Mood Categories and Moods."
 
     @transaction.atomic
     def handle(self, *args, **kwargs):
@@ -50,41 +191,44 @@ class Command(BaseCommand):
         category_objects = {}
         for data in CATEGORY_DATA:
             category, created = MoodCategory.objects.update_or_create(
-                value=data['value'],
+                value=data["value"],
                 # CORRECTED: Uses 'icon' instead of 'icon_url'
-                defaults={'label': data['label'], 'icon': data['icon']}
+                defaults={"label": data["label"], "icon": data["icon"]},
             )
             category_objects[category.value] = category
             if created:
                 self.stdout.write(f"   Created category: {category.label}")
-        
-        self.stdout.write(self.style.SUCCESS(f"Successfully seeded {len(category_objects)} Mood Categories."))
-        
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully seeded {len(category_objects)} Mood Categories."
+            )
+        )
+
         # 2. SEED MOODS
         self.stdout.write("\n2. Seeding Moods...")
         moods_created = 0
         moods_updated = 0
-        
+
         for mood_data in MOODS_TO_SEED:
-            category_value = mood_data.pop('category_value') # Get the category string
+            category_value = mood_data.pop("category_value")  # Get the category string
             category_instance = category_objects.get(category_value)
-            
+
             # Prepare the defaults for update_or_create
             defaults = {
                 # CORRECTED: Maps 'emoji' from data to 'emoji_char' on the model
-                'emoji_char': mood_data.pop('emoji_char'), 
+                "emoji_char": mood_data.pop("emoji_char"),
                 # CORRECTED: Maps 'image_url' from data to 'icon' on the model
-                'icon': mood_data.pop('icon'),
+                "icon": mood_data.pop("icon"),
                 # CORRECTED: Sets the Foreign Key instance
-                'category': category_instance,
-                'is_active': mood_data.pop('is_active', True)
+                "category": category_instance,
+                "is_active": mood_data.pop("is_active", True),
             }
-            
+
             mood, created = Mood.objects.update_or_create(
-                name=mood_data['name'],
-                defaults=defaults
+                name=mood_data["name"], defaults=defaults
             )
-            
+
             if created:
                 moods_created += 1
             else:

--- a/backend/moods/serializers.py
+++ b/backend/moods/serializers.py
@@ -1,41 +1,46 @@
 from rest_framework import serializers
-# Assuming Mood and MoodCategory are correctly imported from .models
-from .models import Mood, MoodCategory, CATEGORY_CHOICES 
 
-# Cloudinary icon mapping (Used for seeding, we will use the model's icon field for output)
-CATEGORY_ICONS = {
-    "positive": "https://res.cloudinary.com/dirn4gqky/image/upload/v1757663590/Positive_yaegjw.svg",
-    # ... other URLs ...
-}
+# Assuming Mood and MoodCategory are correctly imported from .models
+from .models import Mood, MoodCategory
+from .constants import CATEGORY_NUMERIC_MAPPING
+
 
 class MoodCategorySerializer(serializers.ModelSerializer):
     """
     Serializer for the MoodCategory model.
-    The output fields are exactly: value, label, icon.
+    The output fields are exactly: value, label, icon, numeric_value.
     """
+
+    numeric_value = serializers.SerializerMethodField()
+
     class Meta:
         model = MoodCategory
         # Uses the model's 'icon' field (the URL) directly.
-        fields = ['value', 'label', 'icon']
-        
+        fields = ["value", "label", "icon", "numeric_value"]
+
+    def get_numeric_value(self, obj):
+        """Returns a numeric representation of the category."""
+        return CATEGORY_NUMERIC_MAPPING.get(obj.value.lower(), 0)
+
+
 class MoodSerializer(serializers.ModelSerializer):
     """
     Serializer for the Mood model.
     The output fields are: id, name, emoji, category, icon.
     """
-    
+
     # Map the internal 'emoji_char' model field to the API output field 'emoji'
-    emoji = serializers.CharField(source='emoji_char', read_only=True)
-    
+    emoji = serializers.CharField(source="emoji_char", read_only=True)
+
     # Map the ForeignKey 'category' to its 'value' string
-    category = serializers.CharField(source='category.value', read_only=True)
-    
+    category = serializers.CharField(source="category.value", read_only=True)
+
     # The 'icon' field is taken directly from the model
 
     class Meta:
         model = Mood
         # FINAL FIELDS: id, name, emoji, category, icon (URL)
-        fields = ["id", "name", "emoji", "category", "icon"] 
+        fields = ["id", "name", "emoji", "category", "icon"]
         read_only_fields = ("id",)
 
     def validate_name(self, value):
@@ -43,13 +48,15 @@ class MoodSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Name cannot be empty.")
         return value
 
+
 class MoodsCategoriesSerializer(serializers.Serializer):
     """
     Serializer for the final API response structure: {categories: [], moods: []}.
     """
+
     categories = serializers.SerializerMethodField()
     moods = serializers.SerializerMethodField()
-    
+
     def get_categories(self, obj):
         """Returns a list of all defined categories using the MoodCategorySerializer."""
         # Fetch categories from the model for the most accurate data


### PR DESCRIPTION
This pull request introduces improvements to the mood categorization and insights caching system. The most significant changes include standardizing mood category mappings, enhancing the caching mechanism for weekly insights, and updating serializers and seed data for consistency and new features.

**Mood category mapping and serialization improvements: **

* Added a centralized `CATEGORY_NUMERIC_MAPPING` in `backend/moods/constants.py` to map mood categories to numeric values, replacing the previous hardcoded mapping in `insights/services.py`. This mapping is now used throughout the codebase for consistency. [[1]](diffhunk://#diff-97bb80f5ca73b6a743661291662c26f3bf7fbd3dd6a0a21b1be0d5f11ce6e46fR18-R26) [[2]](diffhunk://#diff-b607bc024efe3b5552755606f3cdd054844d3e816881277116455f78f7c23c62R14-L25) [[3]](diffhunk://#diff-b607bc024efe3b5552755606f3cdd054844d3e816881277116455f78f7c23c62L95-R87) [[4]](diffhunk://#diff-b607bc024efe3b5552755606f3cdd054844d3e816881277116455f78f7c23c62L110-R107)
* Updated `MoodCategorySerializer` in `backend/moods/serializers.py` to include a new `numeric_value` field, which provides the numeric representation of the category using the centralized mapping.
* Refactored `MoodSerializer` and related serializers to use consistent field names and improved validation. [[1]](diffhunk://#diff-e2b437db08f317c65311866c2defd821073b79d11a4ed6a214a109ad2a9f0a50L28-R36) [[2]](diffhunk://#diff-e2b437db08f317c65311866c2defd821073b79d11a4ed6a214a109ad2a9f0a50R51-R56)

**Insights caching and signals:**

* Added new signal handlers in `backend/insights/signals.py` to clear weekly insights cache for a user when a `Note` is created or deleted, ensuring up-to-date insights data.
* Registered the new signals in the `ready` method of the `InsightsConfig` app config.

**Seed data and management command updates:**

* Reformatted and cleaned up seed data in `backend/moods/management/commands/seed_moods.py` for better readability and consistency, including proper field usage and code style improvements. [[1]](diffhunk://#diff-bb4c06972c1b0c6d7f61c8990f017a0682eb965e5710d2fb42a18f14c0e092b4L3-R183) [[2]](diffhunk://#diff-bb4c06972c1b0c6d7f61c8990f017a0682eb965e5710d2fb42a18f14c0e092b4L53-R229)